### PR TITLE
Set SUBDIRS equal to autoconf variable RTLIBSUBSYS

### DIFF
--- a/lib/makefile.in
+++ b/lib/makefile.in
@@ -4,7 +4,7 @@
 
 herefromroot = lib
 rootfromhere = ..
-SUBDIRS = guide
+SUBDIRS = @RTLIBSUBSYS@
 
 PACKAGE_SHORTNAME = @PACKAGE_SHORTNAME@
 PACKAGE_NAME = @PACKAGE_NAME@


### PR DESCRIPTION
Otherwise, the make "dist" target fails if Gambit Universal IDE
(guide) is disabled by configure.

Assuming configure does not enable guide, how to repeat:

```
$ git clone git://github.com/feeley/gambit.git
$ cd gambit
$ ./configure --enable-single-host --enable-c-opt --enable-gcc-opts --enable-multiple-versions
$ make bootstrap
$ make bootclean
$ make
$ make dist
   :
   :
making dist in guide
mkdir ../../gambc-v4_6_6/lib/guide
chmod 777 ../../gambc-v4_6_6/lib/guide
  Copying distribution files:
    lib/guide/makefile.in
    lib/guide/guidepro.in
    lib/guide/_guide.scm
    lib/guide/_guide#.scm
    lib/guide/guideuicodeformat.cpp
    lib/guide/guideuirepl.cpp
    lib/guide/guideuihighlighter.cpp
    lib/guide/guideuihighlighterscheme.cpp
    lib/guide/guideuischeme.cpp
    lib/guide/guideuiconsoleinfo.cpp
    lib/guide/guideuitextedit.cpp
    lib/guide/guideuicont.cpp
    lib/guide/guideuienv.cpp
    lib/guide/guideuiinspector.cpp
    lib/guide/guide.cpp
    lib/guide/guideuicodeformat.h
    lib/guide/guideuirepl.h
    lib/guide/guideuitableitem.h
    lib/guide/guideuihighlighter.h
    lib/guide/guideuihighlighterscheme.h
    lib/guide/guideuischeme.h
    lib/guide/guideuiconsoleinfo.h
    lib/guide/guideuitextedit.h
    lib/guide/guideuicont.h
    lib/guide/guideuienv.h
    lib/guide/guideuiinspector.h
    lib/guide/_guide.h
    lib/guide/guide.h
    lib/guide/guideuimainwindow.ui
    lib/guide/guideuifileeditor.ui
    lib/guide/guideuiformatchooser.ui
    lib/guide/guideuisearchdialog.ui
    lib/guide/guideuiabout.ui
    lib/guide/_guide.c
cp: _guide.c: No such file or directory
make[2]: *** [dist-pre] Error 1
make[1]: *** [dist-recursive] Error 1
make: *** [dist-recursive] Error 1
```
