### PR TITLE
Add make "doc" as prerequisite to make "dist" and "dist-devel" targets

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -476,13 +476,13 @@ rc-setup-post: rc-setup-recursive
 
 rc-setup-recursive: rc-setup-pre
 
-dist: dist-post
+dist: doc dist-post
 
 dist-post: dist-recursive
 
 dist-recursive: dist-pre
 
-dist-devel: dist-devel-post
+dist-devel: doc dist-devel-post
 
 dist-devel-post: dist-devel-recursive
 


### PR DESCRIPTION
Otherwise, make "dist" and make "dist-devel" fails due to missing
documentation deliverables.

After applying the patch from https://github.com/feeley/gambit/pull/3, how to repeat:

```
$ make diet
  :
  :
making dist in doc
mkdir ../gambc-v4_6_6/doc
chmod 777 ../gambc-v4_6_6/doc
  Copying distribution files:
    doc/makefile.in
    doc/gambit-c.txi
    doc/texinfo.tex
    doc/texi2html
    doc/checkdoc.scm
    doc/gambcini.scm
    doc/square.scm
    doc/bench.scm
    doc/m1.c
    doc/m2.scm
    doc/m3.scm
    doc/m4.scm
    doc/m5.scm
    doc/m6.scm
    doc/m7.scm
    doc/x.c
    doc/x.h
    doc/h.scm
    doc/w.six
    doc/test1.scm
    doc/test2.scm
    doc/test3.scm
    doc/gsi.1
    doc/stamp.vti
cp: stamp.vti: No such file or directory
    doc/version.txi
cp: version.txi: No such file or directory
    doc/gambit-c.pdf
cp: gambit-c.pdf: No such file or directory
    doc/gambit-c*.html
cp: gambit-c*.html: No such file or directory
    doc/gambit-c.txt
cp: gambit-c.txt: No such file or directory
    doc/gambit-c.info
cp: gambit-c.info: No such file or directory
    doc/gambit-c.info-1
cp: gambit-c.info-1: No such file or directory
    doc/gambit-c.info-2
cp: gambit-c.info-2: No such file or directory
    doc/gambit-c.info-3
cp: gambit-c.info-3: No such file or directory
make[1]: *** [dist-pre] Error 1
make: *** [dist-recursive] Error 1
```
