### PR TITLE
Implemented |##device-port-wait-for-output!| in lib/_io.scm as a complement to |##device-port-wait-for-input!| defined in the same file.

### DIFF
--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -1809,13 +1809,20 @@
   ;; The thread will wait until the port's device is writeable in the
   ;; sense that more data can be written to it, or the port's timeout
   ;; is reached.  The value #f is returned when the timeout is reached.
-  ;; The value #t is returned when the port's device is writeable or the
-  ;; thread was interrupted (for example with thread-interrupt!).
+  ;; The value #t is returned when the port's device is writeable or
+  ;; the thread was interrupted (for example with thread-interrupt!).
 
-  ;; An example of when a port is not writeable is when a TCP client port
-  ;; has full OS transmit buffers. For such a port, a
+  ;; An example of when a port is not writeable is when a TCP client
+  ;; port has full OS transmit buffers. For such a port, a
   ;; ##device-port-wait-for-output! on it will return when space has
   ;; become available in the buffers.
+  ;;
+  ;; Additionally, waiting for writability on a TCP client port is a way
+  ;; to ensure that the connection has been established at all in the
+  ;; first place. This may be of relevance to determine in some lowlevel
+  ;; use scenarios, as Gambit does TCP connect:s asynchronously in such
+  ;; a way that open-tcp-client returns the TCP client port object
+  ;; actually prior to the connection having been established.
 
   (##declare (not interrupts-enabled))
 


### PR DESCRIPTION
Implemented |##device-port-wait-for-output!| in lib/_io.scm , as a complement to |##device-port-wait-for-input!| defined in the same file. If not else, the combination of these two procedures make a working concept of using Gambit as IO multiplexer for a program that does the actual socket reads and writes in C. This is a usecase that has been proven reliable and is really valuable. Suggesting it for inclusion in Gambit as implementing it in user code relies on an unelegant reverse-engineering hack of the port object structure that may break for future Gambit versions. This commit is public domain, I claim no copyright on it.
