### PR TITLE
Trival: ___KEY_OBJ -> ___KEYOBJ in lib/mem.c

### DIFF
--- a/lib/mem.c
+++ b/lib/mem.c
@@ -1606,7 +1606,7 @@ int indent;)
         ___printf ("#<unbound2>\n");
       else if (obj == ___OPTIONAL)
         ___printf ("#!optional\n");
-      else if (obj == ___KEY_OBJ)
+      else if (obj == ___KEYOBJ)
         ___printf ("#!key\n");
       else if (obj == ___REST)
         ___printf ("#!rest\n");


### PR DESCRIPTION
___KEY_OBJ was renamed to ___KEYOBJ a little while back, but mem.c
hasn't been updated.

Clean boostrap fails to compile as a result:

mem.c: In function 'print_object':
mem.c:1609:23: error: '___KEY_OBJ' undeclared (first use in this function)
mem.c:1609:23: note: each undeclared identifier is reported only once for each function it appears in
make[1]: **\* [mem.o] Error 1
