### PR TITLE
Unbreak poll config guard

### DIFF
--- a/include/config.h.in
+++ b/include/config.h.in
@@ -219,7 +219,7 @@
 #undef ___IMPORTED_ID_SUFFIX
 
 /* Define as 1 if you want to enable poll support */
-#undef USE_POLL
+#undef USE_POLL_FOR_SELECT
 
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
The autconf variable was renamed to ENABLE_POLL_FOR_SELECT for 4.6.9, but the configure variable was not, resulting on poll not becoming enabled with --enable-poll-support.
