### PR TITLE
Fix build on OpenBSD's mips64 platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1059,7 +1059,14 @@ else
 
   AC_CHECK_FUNCS(hstrerror)
 
-  AC_CHECK_FUNCS(get_fpc_csr)
+  case "$target_os" in
+    OpenBSD*)
+      # OpenBSD/mips64(el) does have get_fpc_csr(), but lacks union fpc_csr.
+      ;;
+    *)
+      AC_CHECK_FUNCS(get_fpc_csr)
+      ;;
+  esac
 
 fi
 


### PR DESCRIPTION
OpenBSD's mips64 platforms (such as OpenBSD/sgi) do provide an get_fpc_csr(),
but lack the union fpc_csr. The configure script checks for get_fpc_csr() and
assumes union fpc_csr is also present (this is true for Irix, but not OpenBSD).
