### PR TITLE
Do (expt x k/2) carefully for complex x, add unit tests.

### DIFF
--- a/lib/_num.scm
+++ b/lib/_num.scm
@@ -3117,7 +3117,14 @@ for a discussion of branch cuts.
                  (complex-expt x y)))
             (else
              (##flonum.expt x (##flonum.<-ratnum y))))
-      (complex-expt x y))
+      (or (and (##eq? 2 (macro-ratnum-denominator y))
+	       (or (and (##eq? 1 (macro-ratnum-numerator y))
+			(##sqrt x))
+		   (and (##exact? x)
+			(let ((sqrt-x (##sqrt x)))
+			  (and (##exact? sqrt-x)
+			       (##* sqrt-x (##expt x (##quotient (##- (macro-ratnum-numerator y) 1) 2))))))))
+	  (complex-expt x y)))
 
     (macro-number-dispatch x (##fail-check-number 1 expt x y) ;; y a flonum
       (cond ((##flonum.nan? y)

--- a/tests/unit-tests/03-number/expt.scm
+++ b/tests/unit-tests/03-number/expt.scm
@@ -1,5 +1,21 @@
 (include "#.scm")
 
+;;; Test values
+
+(check-eqv? (expt 2 3) 8)
+(check-eqv? (expt 2 -3) 1/8)
+(check-eqv? (expt 8 1/3) 2)
+(check-eqv? (expt 1+i 2) +2i)
+(check-eqv? (expt +2i 1/2) 1+i)
+(check-eqv? (expt +2i 3/2) -2+2i)
+(check-eqv? (expt -2i 1/2) 1-i)
+(check-eqv? (expt -2i 3/2) -2-2i)
+(check-eqv? (expt 8/27 1/3) 2/3)
+(check-eqv? (expt -8/27 1/3) 1/3+.5773502691896257i)
+(check-eqv? (expt 4.0 1/2) 2.0)
+(check-eqv? (expt 4 .5) 2.0)
+(check-eqv? (expt 1+i 1/2) (sqrt 1+i))
+
 ;;; Test exceptions
 
 (check-tail-exn type-exception? (lambda () (expt 'a 2)))


### PR DESCRIPTION
(expt x 1/2) should always be the same as (sqrt x).  Make it so.  Do (expt x k/2) correctly when the answer is complex exact.
