### PR TITLE
Improve iOS Build Script

### DIFF
--- a/misc/build-gambit-iOS
+++ b/misc/build-gambit-iOS
@@ -133,6 +133,7 @@ make_gambit()
 {
   dir="$1"
   cd "$dir"
+  cd "lib"
   make clean
   if [ "$update_with_latest_changes" == "yes" ]; then
      echo "Updating to latest from master"
@@ -142,6 +143,7 @@ make_gambit()
      make -j $num_simultaneous_jobs || exit 1
   fi
   make install
+  cd ..
   cd ..
 }
 


### PR DESCRIPTION
1. Update default archs to drop armv6, which isn't supported by recent Xcode's, and add armv7s, for the newer devices.
2. Add -j option which will get passed to make.
3. Add -h usage description.
