### PR TITLE
Complete build options for Pthread API.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@
 
 AC_INIT(Gambit-C,v4.7.2,gambit@iro.umontreal.ca,gambc-v4_7_2)
 
+AC_CONFIG_MACRO_DIRS([m4])
 AC_CONFIG_HEADERS(include/config.h)
 
 PACKAGE_SHORTNAME="gambc"
@@ -1254,94 +1255,48 @@ AC_CHECK_TYPE([struct stat64],
 # Check for threading system early, in case this has an impact on
 # other functionality.
 
-CONF_THREAD_SYSTEM="___USE_NO_THREAD_SYSTEM"
-CONF_THREAD_LOCAL_STORAGE_CLASS="___NO_THREAD_LOCAL_STORAGE_CLASS"
+if test "x$ENABLE_THREAD_SYSTEM" = xno; then
 
-if test "$ENABLE_THREAD_SYSTEM" != no; then
+  CONF_THREAD_SYSTEM=___USE_NO_THREAD_SYSTEM
+  CONF_THREAD_LOCAL_STORAGE_CLASS=___NO_THREAD_LOCAL_STORAGE_CLASS
 
-  FOUND_THREAD_SYSTEM="no"
+else
 
-  if test "$FOUND_THREAD_SYSTEM" = no -a \( "$ENABLE_THREAD_SYSTEM" = yes -o "$ENABLE_THREAD_SYSTEM" = posix -o "$ENABLE_THREAD_SYSTEM" = pthreads \); then
+  case $ENABLE_THREAD_SYSTEM in
+    posix|pthreads|yes|'')
+      AX_PTHREAD([LIBS="$PTHREAD_LIBS $LIBS"
 
-    # check if posix thread system is available
+                  if test "x$ENABLE_CPLUSPLUS" = xyes; then
+                    CXXFLAGS="$PTHREAD_CFLAGS $CXXFLAGS"
+                  fi
 
-    ORIG_CFLAGS="$CFLAGS"
-    ORIG_LIBS="$LIBS"
+                  CFLAGS="$PTHREAD_CFLAGS $CFLAGS"
+                  CC="$PTHREAD_CC"
+                  CONF_THREAD_SYSTEM=___USE_POSIX_THREAD_SYSTEM],
+                 [AC_MSG_ERROR([Pthread API support is required.])])
+      ;;
 
-    for opt in "" "OPT_CFLAGS=\"-mt\"" "OPT_CFLAGS=\"-pthread\"" "OPT_LIBS=\"-lpthread\""; do
+    win32)
+      AC_MSG_CHECKING([for win32 threads])
 
-      OPT_CFLAGS=""
-      OPT_LIBS=""
+      if test "x$OS_WIN32" = xyes; then
+        AC_MSG_RESULT([yes])
+        CONF_THREAD_SYSTEM=___USE_WIN32_THREAD_SYSTEM
+      else
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([Win32 API support is required.])
+      fi
+      ;;
 
-      eval "$opt"
-
-      CFLAGS="$ORIG_CFLAGS $OPT_CFLAGS"
-      LIBS="$ORIG_LIBS $OPT_LIBS"
-
-      AC_MSG_CHECKING([for posix threads with CFLAGS='$CFLAGS' and LIBS='$LIBS'])
-
-      AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM([
-           #include <pthread.h>
-           void *start_fn (void *ptr) { return ptr; }
-        ],[
-           pthread_t thread;
-           pthread_mutex_t mut;
-           if (pthread_mutex_init (&mut, NULL) == 0 &&
-               pthread_mutex_lock (&mut) == 0 &&
-               pthread_mutex_unlock (&mut) == 0 &&
-               pthread_mutex_destroy (&mut) == 0) {
-             pthread_create (&thread, NULL, start_fn, NULL);
-             pthread_join (&thread, NULL);
-           }
-        ])],[
-         AC_MSG_RESULT([yes])
-         FOUND_THREAD_SYSTEM="posix"
-         FLAGS_OBJ="$FLAGS_OBJ $OPT_CFLAGS"
-         break
-        ],[
-         AC_MSG_RESULT([no])
-         LIBS="$ORIG_LIBS"
-        ])
-
-      CFLAGS="$ORIG_CFLAGS"
-
-    done
-
-  fi
-
-  if test "$FOUND_THREAD_SYSTEM" = no -a \( "$ENABLE_THREAD_SYSTEM" = yes -o "$ENABLE_THREAD_SYSTEM" = win32 \); then
-
-    # check if win32 thread system is available
-
-    AC_MSG_CHECKING([for win32 threads])
-
-    if test "$OS_WIN32" = yes; then
-      AC_MSG_RESULT([yes])
-      FOUND_THREAD_SYSTEM="win32"
-    else
-      AC_MSG_RESULT([no])
-    fi
-
-  fi
-
-  if test "$FOUND_THREAD_SYSTEM" != no; then
-
-    case "$FOUND_THREAD_SYSTEM" in
-
-      posix)
-        CONF_THREAD_SYSTEM="___USE_POSIX_THREAD_SYSTEM"
-        ;;
-
-      win32)
-        CONF_THREAD_SYSTEM="___USE_WIN32_THREAD_SYSTEM"
-        ;;
+    *)
+      AC_MSG_ERROR([The unknown thread interface "${ENABLE_THREAD_SYSTEM}" was requested.])
+      ;;
 
     esac
 
     AC_MSG_CHECKING([for thread local storage class])
 
-    TLS_CLASS="none"
+    TLS_CLASS=none
 
     for tls_class in "__thread" "__declspec(thread)"; do
       AC_TRY_COMPILE([
@@ -1352,49 +1307,13 @@ if test "$ENABLE_THREAD_SYSTEM" != no; then
        ],[TLS_CLASS="$tls_class"; break])
     done
 
-    AC_MSG_RESULT($TLS_CLASS)
+    AC_MSG_RESULT([$TLS_CLASS])
 
-    if test "$TLS_CLASS" != none; then
+    if test "$TLS_CLASS" = none; then
+      CONF_THREAD_LOCAL_STORAGE_CLASS=___NO_THREAD_LOCAL_STORAGE_CLASS
+    else
       CONF_THREAD_LOCAL_STORAGE_CLASS="___THREAD_LOCAL_STORAGE_CLASS $TLS_CLASS"
     fi
-
-  else
-
-    if test "$ENABLE_THREAD_SYSTEM" = yes; then
-
-      AC_MSG_NOTICE([
-*********************************************************************
-***                                                               ***
-*** A thread system is required for this configuration but none   ***
-*** of the supported thread systems (posix threads and win32      ***
-*** threads) are available on this platform. The configuration    ***
-*** will proceed as though --disable-thread-system,               ***
-*** --disable-multiple-vms, and --disable-multiple-threaded-vms   ***
-*** were specified.                                               ***
-***                                                               ***
-*********************************************************************
-])
-
-    else
-
-      AC_MSG_NOTICE([
-*********************************************************************
-***                                                               ***
-*** The thread system selected with --enable-thread-system=XXX    ***
-*** is not available on this platform. The configuration will     ***
-*** proceed as though --disable-thread-system,                    ***
-*** --disable-multiple-vms, and --disable-multiple-threaded-vms   ***
-*** were specified.                                               ***
-***                                                               ***
-*********************************************************************
-])
-
-    fi
-
-    CONF_SINGLE_MULTIPLE_VMS="___SINGLE_VM"
-    CONF_SINGLE_MULTIPLE_THREADED_VMS="___SINGLE_THREADED_VMS"
-
-  fi
 
 fi
 

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -1,0 +1,332 @@
+# ===========================================================================
+#        http://www.gnu.org/software/autoconf-archive/ax_pthread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PTHREAD([ACTION-IF-FOUND[, ACTION-IF-NOT-FOUND]])
+#
+# DESCRIPTION
+#
+#   This macro figures out how to build C programs using POSIX threads. It
+#   sets the PTHREAD_LIBS output variable to the threads library and linker
+#   flags, and the PTHREAD_CFLAGS output variable to any special C compiler
+#   flags that are needed. (The user can also force certain compiler
+#   flags/libs to be tested by setting these environment variables.)
+#
+#   Also sets PTHREAD_CC to any special C compiler that is needed for
+#   multi-threaded programs (defaults to the value of CC otherwise). (This
+#   is necessary on AIX to use the special cc_r compiler alias.)
+#
+#   NOTE: You are assumed to not only compile your program with these flags,
+#   but also link it with them as well. e.g. you should link with
+#   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#
+#   If you are only building threads programs, you may wish to use these
+#   variables in your default LIBS, CFLAGS, and CC:
+#
+#     LIBS="$PTHREAD_LIBS $LIBS"
+#     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CC="$PTHREAD_CC"
+#
+#   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
+#   has a nonstandard name, defines PTHREAD_CREATE_JOINABLE to that name
+#   (e.g. PTHREAD_CREATE_UNDETACHED on AIX).
+#
+#   Also HAVE_PTHREAD_PRIO_INHERIT is defined if pthread is found and the
+#   PTHREAD_PRIO_INHERIT symbol is defined when compiling with
+#   PTHREAD_CFLAGS.
+#
+#   ACTION-IF-FOUND is a list of shell commands to run if a threads library
+#   is found, and ACTION-IF-NOT-FOUND is a list of commands to run it if it
+#   is not found. If ACTION-IF-FOUND is not specified, the default action
+#   will define HAVE_PTHREAD.
+#
+#   Please let the authors know if this macro fails on any platform, or if
+#   you have any other suggestions or comments. This macro was based on work
+#   by SGJ on autoconf scripts for FFTW (http://www.fftw.org/) (with help
+#   from M. Frigo), as well as ac_pthread and hb_pthread macros posted by
+#   Alejandro Forero Cuervo to the autoconf macro repository. We are also
+#   grateful for the helpful feedback of numerous users.
+#
+#   Updated for Autoconf 2.68 by Daniel Richard G.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 21
+
+AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
+AC_DEFUN([AX_PTHREAD], [
+AC_REQUIRE([AC_CANONICAL_HOST])
+AC_LANG_PUSH([C])
+ax_pthread_ok=no
+
+# We used to check for pthread.h first, but this fails if pthread.h
+# requires special compiler flags (e.g. on True64 or Sequent).
+# It gets checked for in the link test anyway.
+
+# First of all, check if the user has set any of the PTHREAD_LIBS,
+# etcetera environment variables, and if threads linking works using
+# them:
+if test x"$PTHREAD_LIBS$PTHREAD_CFLAGS" != x; then
+        save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+        save_LIBS="$LIBS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        AC_MSG_CHECKING([for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS])
+        AC_TRY_LINK_FUNC([pthread_join], [ax_pthread_ok=yes])
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test x"$ax_pthread_ok" = xno; then
+                PTHREAD_LIBS=""
+                PTHREAD_CFLAGS=""
+        fi
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+fi
+
+# We must check for the threads library under a number of different
+# names; the ordering is very important because some systems
+# (e.g. DEC) have both -lpthread and -lpthreads, where one of the
+# libraries is broken (non-POSIX).
+
+# Create a list of thread flags to try.  Items starting with a "-" are
+# C compiler flags, and other items are library names, except for "none"
+# which indicates that we try without any flags at all, and "pthread-config"
+# which is a program returning the flags for the Pth emulation library.
+
+ax_pthread_flags="pthreads none -Kthread -kthread lthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
+
+# The ordering *is* (sometimes) important.  Some notes on the
+# individual items follow:
+
+# pthreads: AIX (must check this before -lpthread)
+# none: in case threads are in libc; should be tried before -Kthread and
+#       other compiler flags to prevent continual compiler warnings
+# -Kthread: Sequent (threads in libc, but -Kthread needed for pthread.h)
+# -kthread: FreeBSD kernel threads (preferred to -pthread since SMP-able)
+# lthread: LinuxThreads port on FreeBSD (also preferred to -pthread)
+# -pthread: Linux/gcc (kernel threads), BSD/gcc (userland threads)
+# -pthreads: Solaris/gcc
+# -mthreads: Mingw32/gcc, Lynx/gcc
+# -mt: Sun Workshop C (may only link SunOS threads [-lthread], but it
+#      doesn't hurt to check since this sometimes defines pthreads too;
+#      also defines -D_REENTRANT)
+#      ... -mt is also the pthreads flag for HP/aCC
+# pthread: Linux, etcetera
+# --thread-safe: KAI C++
+# pthread-config: use pthread-config program (for GNU Pth library)
+
+case ${host_os} in
+        solaris*)
+
+        # On Solaris (at least, for some versions), libc contains stubbed
+        # (non-functional) versions of the pthreads routines, so link-based
+        # tests will erroneously succeed.  (We need to link with -pthreads/-mt/
+        # -lpthread.)  (The stubs are missing pthread_cleanup_push, or rather
+        # a function called by this macro, so we could check for that, but
+        # who knows whether they'll stub that too in a future libc.)  So,
+        # we'll just look for -pthreads and -lpthread first:
+
+        ax_pthread_flags="-pthreads pthread -mt -pthread $ax_pthread_flags"
+        ;;
+
+        darwin*)
+        ax_pthread_flags="-pthread $ax_pthread_flags"
+        ;;
+esac
+
+# Clang doesn't consider unrecognized options an error unless we specify
+# -Werror. We throw in some extra Clang-specific options to ensure that
+# this doesn't happen for GCC, which also accepts -Werror.
+
+AC_MSG_CHECKING([if compiler needs -Werror to reject unknown flags])
+save_CFLAGS="$CFLAGS"
+ax_pthread_extra_flags="-Werror"
+CFLAGS="$CFLAGS $ax_pthread_extra_flags -Wunknown-warning-option -Wsizeof-array-argument"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([int foo(void);],[foo()])],
+                  [AC_MSG_RESULT([yes])],
+                  [ax_pthread_extra_flags=
+                   AC_MSG_RESULT([no])])
+CFLAGS="$save_CFLAGS"
+
+if test x"$ax_pthread_ok" = xno; then
+for flag in $ax_pthread_flags; do
+
+        case $flag in
+                none)
+                AC_MSG_CHECKING([whether pthreads work without any flags])
+                ;;
+
+                -*)
+                AC_MSG_CHECKING([whether pthreads work with $flag])
+                PTHREAD_CFLAGS="$flag"
+                ;;
+
+                pthread-config)
+                AC_CHECK_PROG([ax_pthread_config], [pthread-config], [yes], [no])
+                if test x"$ax_pthread_config" = xno; then continue; fi
+                PTHREAD_CFLAGS="`pthread-config --cflags`"
+                PTHREAD_LIBS="`pthread-config --ldflags` `pthread-config --libs`"
+                ;;
+
+                *)
+                AC_MSG_CHECKING([for the pthreads library -l$flag])
+                PTHREAD_LIBS="-l$flag"
+                ;;
+        esac
+
+        save_LIBS="$LIBS"
+        save_CFLAGS="$CFLAGS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS $ax_pthread_extra_flags"
+
+        # Check for various functions.  We must include pthread.h,
+        # since some functions may be macros.  (On the Sequent, we
+        # need a special flag -Kthread to make this header compile.)
+        # We check for pthread_join because it is in -lpthread on IRIX
+        # while pthread_create is in libc.  We check for pthread_attr_init
+        # due to DEC craziness with -lpthreads.  We check for
+        # pthread_cleanup_push because it is one of the few pthread
+        # functions on Solaris that doesn't have a non-functional libc stub.
+        # We try pthread_create on general principles.
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>
+                        static void routine(void *a) { a = 0; }
+                        static void *start_routine(void *a) { return a; }],
+                       [pthread_t th; pthread_attr_t attr;
+                        pthread_create(&th, 0, start_routine, 0);
+                        pthread_join(th, 0);
+                        pthread_attr_init(&attr);
+                        pthread_cleanup_push(routine, 0);
+                        pthread_cleanup_pop(0) /* ; */])],
+                [ax_pthread_ok=yes],
+                [])
+
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+
+        AC_MSG_RESULT([$ax_pthread_ok])
+        if test "x$ax_pthread_ok" = xyes; then
+                break;
+        fi
+
+        PTHREAD_LIBS=""
+        PTHREAD_CFLAGS=""
+done
+fi
+
+# Various other checks:
+if test "x$ax_pthread_ok" = xyes; then
+        save_LIBS="$LIBS"
+        LIBS="$PTHREAD_LIBS $LIBS"
+        save_CFLAGS="$CFLAGS"
+        CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+
+        # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
+        AC_MSG_CHECKING([for joinable pthread attribute])
+        attr_name=unknown
+        for attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <pthread.h>],
+                           [int attr = $attr; return attr /* ; */])],
+                [attr_name=$attr; break],
+                [])
+        done
+        AC_MSG_RESULT([$attr_name])
+        if test "$attr_name" != PTHREAD_CREATE_JOINABLE; then
+            AC_DEFINE_UNQUOTED([PTHREAD_CREATE_JOINABLE], [$attr_name],
+                               [Define to necessary symbol if this constant
+                                uses a non-standard name on your system.])
+        fi
+
+        AC_MSG_CHECKING([if more special flags are required for pthreads])
+        flag=no
+        case ${host_os} in
+            aix* | freebsd* | darwin*) flag="-D_THREAD_SAFE";;
+            osf* | hpux*) flag="-D_REENTRANT";;
+            solaris*)
+            if test "$GCC" = "yes"; then
+                flag="-D_REENTRANT"
+            else
+                # TODO: What about Clang on Solaris?
+                flag="-mt -D_REENTRANT"
+            fi
+            ;;
+        esac
+        AC_MSG_RESULT([$flag])
+        if test "x$flag" != xno; then
+            PTHREAD_CFLAGS="$flag $PTHREAD_CFLAGS"
+        fi
+
+        AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
+            [ax_cv_PTHREAD_PRIO_INHERIT], [
+                AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
+                                                [[int i = PTHREAD_PRIO_INHERIT;]])],
+                    [ax_cv_PTHREAD_PRIO_INHERIT=yes],
+                    [ax_cv_PTHREAD_PRIO_INHERIT=no])
+            ])
+        AS_IF([test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes"],
+            [AC_DEFINE([HAVE_PTHREAD_PRIO_INHERIT], [1], [Have PTHREAD_PRIO_INHERIT.])])
+
+        LIBS="$save_LIBS"
+        CFLAGS="$save_CFLAGS"
+
+        # More AIX lossage: compile with *_r variant
+        if test "x$GCC" != xyes; then
+            case $host_os in
+                aix*)
+                AS_CASE(["x/$CC"],
+                  [x*/c89|x*/c89_128|x*/c99|x*/c99_128|x*/cc|x*/cc128|x*/xlc|x*/xlc_v6|x*/xlc128|x*/xlc128_v6],
+                  [#handle absolute path differently from PATH based program lookup
+                   AS_CASE(["x$CC"],
+                     [x/*],
+                     [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
+                     [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
+                ;;
+            esac
+        fi
+fi
+
+test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+
+AC_SUBST([PTHREAD_LIBS])
+AC_SUBST([PTHREAD_CFLAGS])
+AC_SUBST([PTHREAD_CC])
+
+# Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
+if test x"$ax_pthread_ok" = xyes; then
+        ifelse([$1],,[AC_DEFINE([HAVE_PTHREAD],[1],[Define if you have POSIX threads libraries and header files.])],[$1])
+        :
+else
+        ax_pthread_ok=no
+        $2
+fi
+AC_LANG_POP
+])dnl AX_PTHREAD


### PR DESCRIPTION
The configuration script "[AX_PTHREAD](http://www.gnu.org/software/autoconf-archive/ax_pthread.html)" should be added to the build specification so that corresponding special parameters will be taken into account.
