### PR TITLE
Fix freeze during tty multibyte output

### DIFF
--- a/lib/os_tty.c
+++ b/lib/os_tty.c
@@ -2332,6 +2332,9 @@ ___device_tty *self;)
           }
 
 #endif
+	  
+	  if (byte_avail ==  ___NBELEMS(d->output_byte) - d->output_byte_hi)
+	    break;  /* not enough space for a full multibyte character, first flush what we have */
 
           d->output_char_lo = d->output_char.length - len;
 


### PR DESCRIPTION
This hopefully correct one-liner avoids an endless loop while outputting utf text to the tty.
