### PR TITLE
Revert change to the OpenBSD test in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1503,7 +1503,8 @@ else
   AC_CHECK_FUNCS(hstrerror)
 
   case "$target_os" in
-    OpenBSD*)
+    # the OpenBSD test is always lowercase
+    openbsd*)
       # OpenBSD/mips64(el) does have get_fpc_csr(), but lacks union fpc_csr.
       ;;
     *)


### PR DESCRIPTION
The commit c70bc28ca496813fa2703c05f4d4a5ad60ea04aa fixed the test but it was reverted again in the commit 1dd58a3808f36756a20554406f742b9c01378e18.