### PR TITLE
Universal backend: fixes various negative zero issues with PHP

### DIFF
--- a/gsc/tests/08-flprim/flcopysign.scm
+++ b/gsc/tests/08-flprim/flcopysign.scm
@@ -1,0 +1,25 @@
+(declare (extended-bindings) (not constant-fold) (not safe))
+
+(define (test a b c)
+  (let ((x (##flcopysign a b)))
+    (println (##fleqv? x c))))
+
+(test 0.0  1.0  0.0)
+(test 0.0 -1.0 -0.0)
+(test 0.0  0.0  0.0)
+(test 0.0 -0.0 -0.0)
+
+(test -0.0  1.0  0.0)
+(test -0.0 -1.0 -0.0)
+(test -0.0  0.0  0.0)
+(test -0.0 -0.0 -0.0)
+
+(test 1.0  1.0  1.0)
+(test 1.0 -1.0 -1.0)
+(test 1.0  0.0  1.0)
+(test 1.0 -0.0 -1.0)
+
+(test -1.0  1.0  1.0)
+(test -1.0 -1.0 -1.0)
+(test -1.0  0.0  1.0)
+(test -1.0 -0.0 -1.0)


### PR DESCRIPTION
As I suspected, most of the failed unit tests were due to the way PHP handles -0.0 (which had an impact on cpxnum implementations of trigonometric functions, among other things).

With these changes, all number-related unit tests should pass with `make ut-php`.