### PR TITLE
Dynamically sized fdsets for poll

### DIFF
--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -8381,6 +8381,15 @@ typedef struct ___sync_op_struct
     ___VOLATILE ___WORD arg[2];   /* arguments of the operation */
   } ___sync_op_struct;
 
+/* fdset state */
+#ifdef USE_POLL_FOR_SELECT
+typedef struct ___fdset_state_struct {
+  int size;
+  void *readfds;
+  void *writefds;
+} ___fdset_state;
+#endif
+
 /* Processor structure */
 
 typedef struct ___processor_state_struct
@@ -8462,6 +8471,10 @@ typedef struct ___processor_state_struct
     ___MUTEX_DECL(sync_mut)
     ___CONDVAR_DECL(sync_cv)
 
+#endif
+
+#ifdef USE_POLL_FOR_SELECT
+    ___fdset_state fdset_state;
 #endif
   } ___processor_state_struct;
 

--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -8146,6 +8146,15 @@ typedef struct ___rc_header_struct
     ___SCMOBJ data; /* needed for C closures */
   } ___rc_header;
 
+/* fdset state */
+#ifdef USE_POLL_FOR_SELECT
+typedef struct ___fdset_state_struct {
+  int size;
+  void *readfds;
+  void *writefds;
+} ___fdset_state;
+#endif
+
 typedef struct ___pstate_os_struct {
 
   /*
@@ -8157,6 +8166,11 @@ typedef struct ___pstate_os_struct {
 #else
   ___half_duplex_pipe select_abort; /* POSIX self-pipe */
 #endif
+  
+#ifdef USE_POLL_FOR_SELECT
+    ___fdset_state fdset_state;
+#endif
+
 
 } ___pstate_os;
 
@@ -8381,15 +8395,6 @@ typedef struct ___sync_op_struct
     ___VOLATILE ___WORD arg[2];   /* arguments of the operation */
   } ___sync_op_struct;
 
-/* fdset state */
-#ifdef USE_POLL_FOR_SELECT
-typedef struct ___fdset_state_struct {
-  int size;
-  void *readfds;
-  void *writefds;
-} ___fdset_state;
-#endif
-
 /* Processor structure */
 
 typedef struct ___processor_state_struct
@@ -8471,10 +8476,6 @@ typedef struct ___processor_state_struct
     ___MUTEX_DECL(sync_mut)
     ___CONDVAR_DECL(sync_cv)
 
-#endif
-
-#ifdef USE_POLL_FOR_SELECT
-    ___fdset_state fdset_state;
 #endif
   } ___processor_state_struct;
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -84,27 +84,27 @@ static void ___fdset_realloc (int fd)
   int newsize = oldsize;
   while (newsize <= fd)
     {
-      newsize = newisze * 2;
+      newsize = newsize * 2;
     }
 
   ___fdset_state_readfds = realloc (___fdset_state_readfds, newsize/8);
   ___fdset_state_writefds = realloc (___fdset_state_writefds, newsize/8);
   ___fdset_state_size = newsize;
-  memset(___fdset_state_readfds + oldsize/8, 0, (newsize - oldsize)/8)
+  memset(___fdset_state_readfds + oldsize/8, 0, (newsize - oldsize)/8);
   memset(___fdset_state_writefds + oldsize/8, 0, (newsize - oldsize)/8);
 }
 
-static void ___fdset_size ()
+static int ___fdset_size ()
 {
   return ___fdset_state_size;
 }
 
-static void ___fdset_readfds ()
+static ___poll_fdset ___fdset_readfds ()
 {
   return ___fdset_state_readfds;
 }
 
-static void ___fdset_writefds ()
+static ___poll_fdset ___fdset_writefds ()
 {
   return ___fdset_state_writefds;
 }
@@ -774,9 +774,9 @@ int fd;
 ___BOOL for_writing;)
 {
   if (for_writing)
-    ___FD_SET(fd, &state->writefds);
+    ___FD_SET(fd, state->writefds);
   else
-    ___FD_SET(fd, &state->readfds);
+    ___FD_SET(fd, state->readfds);
 
   if (fd >= state->highest_fd_plus_1)
     state->highest_fd_plus_1 = fd+1;
@@ -1243,7 +1243,7 @@ ___time timeout;)
 
 #ifdef USE_ASYNC_DEVICE_SELECT_ABORT
 
-  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, &state.readfds))
+  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, state.readfds))
     {
       /* self-pipe has available data to read, discard all of it */
 
@@ -1422,7 +1422,7 @@ ___time timeout;)
 
 #ifdef USE_select_or_poll
 
-  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, &state.readfds))
+  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, state.readfds))
     {
       /* self-pipe has available data to read, discard all of it */
 
@@ -3002,12 +3002,12 @@ ___device_select_state *state;)
 
       if (for_writing)
         {
-          if (d->fd_wr < 0 || ___FD_ISSET(d->fd_wr, &state->writefds))
+          if (d->fd_wr < 0 || ___FD_ISSET(d->fd_wr, state->writefds))
             state->devs[i] = NULL;
         }
       else
         {
-          if (d->fd_rd < 0 || ___FD_ISSET(d->fd_rd, &state->readfds))
+          if (d->fd_rd < 0 || ___FD_ISSET(d->fd_rd, state->readfds))
             state->devs[i] = NULL;
         }
 
@@ -4966,8 +4966,8 @@ ___device_select_state *state;)
 
       if (d->try_connect_again != 0 ||
           (for_writing
-           ? ___FD_ISSET(d->s, &state->writefds)
-           : ___FD_ISSET(d->s, &state->readfds)))
+           ? ___FD_ISSET(d->s, state->writefds)
+           : ___FD_ISSET(d->s, state->readfds)))
         {
           d->connect_done = 1;
           state->devs[i] = NULL;
@@ -5739,7 +5739,7 @@ ___device_select_state *state;)
     {
 #ifdef USE_POSIX
 
-      if (___FD_ISSET(d->s, &state->readfds))
+      if (___FD_ISSET(d->s, state->readfds))
         state->devs[i] = NULL;
 
 #endif
@@ -6677,8 +6677,8 @@ ___device_select_state *state;)
 #ifdef USE_POSIX
 
       if (for_writing
-           ? ___FD_ISSET(d->fd, &state->writefds)
-           : ___FD_ISSET(d->fd, &state->readfds))
+           ? ___FD_ISSET(d->fd, state->writefds)
+           : ___FD_ISSET(d->fd, state->readfds))
         state->devs[i] = NULL;
 
 #endif

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -110,6 +110,17 @@ static ___poll_fdset ___fdset_writefds ()
 }
 #endif
 
+/*---------------------------------------------------------------------------*/
+/* Thread-Local state setup*/
+#ifndef ___SINGLE_THREADED_VMS
+void ___setup_io_thread_local_state ___PVOID
+{
+#ifdef USE_poll
+  ___fdset_state_init ();
+#endif
+
+}
+#endif
 
 /*---------------------------------------------------------------------------*/
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -46,7 +46,7 @@ struct ___fdset_state {
   ___fdbits *writefds;
 };
 
-#ifdef ___USE_POSIX_THREAD_SYSTEM
+#ifndef ___SINGLE_THREADED_VMS
 
 __thread struct ___fdset_state *___fdset_state;
 #define ___fdset_state_size ___fdset_state->size

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -40,9 +40,9 @@ ___io_module ___io_mod =
 /* poll dynamic fdset memory management. */
 
 #ifdef USE_poll
-#define ___fdset_state_size(ps)     ps->fdset_state.size
-#define ___fdset_state_readfds(ps)  ps->fdset_state.readfds
-#define ___fdset_state_writefds(ps) ps->fdset_state.writefds
+#define ___fdset_state_size(ps)     ps->os.fdset_state.size
+#define ___fdset_state_readfds(ps)  ps->os.fdset_state.readfds
+#define ___fdset_state_writefds(ps) ps->os.fdset_state.writefds
 
 void ___fdset_state_init (___processor_state ps)
 {

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -887,9 +887,9 @@ ___time timeout;)
 
   state.highest_fd_plus_1 = 0;
 
-  ___FD_ZERO(&state.readfds);
-  ___FD_ZERO(&state.writefds);
-  ___FD_ZERO(&state.exceptfds);
+  ___FD_ZERO(state.readfds);
+  ___FD_ZERO(state.writefds);
+  ___FD_ZERO(state.exceptfds);
 
 #endif
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -72,9 +72,9 @@ static void ___fdset_alloc ()
 {
   if (!___fdset_state_size)
     {
-      ___fdset_state_readfds = malloc (MAX_CONDVARS/8);
-      ___fdset_state_writefds = malloc (MAX_CONDVARS/8);
-      ___fdset_state_size = MAX_CONDVARS;
+      ___fdset_state_readfds = malloc (MAX_POLLFDS/8);
+      ___fdset_state_writefds = malloc (MAX_POLLFDS/8);
+      ___fdset_state_size = MAX_POLLFDS;
     }
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -40,85 +40,56 @@ ___io_module ___io_mod =
 /* poll dynamic fdset memory management. */
 
 #ifdef USE_poll
-struct ___fdset_state {
-  int size;
-  ___fdbits *readfds;
-  ___fdbits *writefds;
-};
+#define ___fdset_state_size(ps)     ps->fdset_state.size
+#define ___fdset_state_readfds(ps)  ps->fdset_state.readfds
+#define ___fdset_state_writefds(ps) ps->fdset_state.writefds
 
-#ifndef ___SINGLE_THREADED_VMS
-
-__thread struct ___fdset_state *___fdset_state;
-#define ___fdset_state_size ___fdset_state->size
-#define ___fdset_state_readfds ___fdset_state->readfds
-#define ___fdset_state_writefds ___fdset_state->writefds
-
-void ___fdset_state_init ()
+void ___fdset_state_init (___processor_state ps)
 {
-  ___fdset_state = malloc (sizeof (struct ___fdset_state));
-  memset (___fdset_state, 0, sizeof (struct ___fdset_state));
+  ___fdset_state_readfds (ps) = ___ALLOC_MEM (MAX_CONDVARS/8);
+  ___fdset_state_writefds (ps) = ___ALLOC_MEM (MAX_CONDVARS/8);
+  ___fdset_state_size (ps) = MAX_CONDVARS;
 }
 
-#else
-
-static struct ___fdset_state ___fdset_state;
-#define ___fdset_state_size ___fdset_state.size
-#define ___fdset_state_readfds ___fdset_state.readfds
-#define ___fdset_state_writefds ___fdset_state.writefds
-
-#endif
-
-static void ___fdset_alloc ()
+static void ___fdset_realloc (___processor_state ps, int fd)
 {
-  if (!___fdset_state_size)
-    {
-      ___fdset_state_readfds = malloc (MAX_POLLFDS/8);
-      ___fdset_state_writefds = malloc (MAX_POLLFDS/8);
-      ___fdset_state_size = MAX_POLLFDS;
-    }
-}
-
-static void ___fdset_realloc (int fd)
-{
-  int oldsize = ___fdset_state_size;
+  void *readfds, *writefds;
+  int oldsize = ___fdset_state_size (ps);
   int newsize = oldsize;
+
   while (newsize <= fd)
-    {
-      newsize = newsize * 2;
-    }
+    newsize = newsize * 2;
 
-  ___fdset_state_readfds = realloc (___fdset_state_readfds, newsize/8);
-  ___fdset_state_writefds = realloc (___fdset_state_writefds, newsize/8);
-  ___fdset_state_size = newsize;
-  memset(___fdset_state_readfds + oldsize/8, 0, (newsize - oldsize)/8);
-  memset(___fdset_state_writefds + oldsize/8, 0, (newsize - oldsize)/8);
+  if (oldsize == newsize) /* we never shrink fdsets */
+      return;
+
+  readfds  = ___ALLOC_MEM (newsize/8);
+  writefds = ___ALLOC_MEM (newsize/8);
+  memcpy (readfds, ___fdset_state_readfds (ps), oldsize/8);
+  memcpy (writefds, ___fdset_state_writefds (ps), oldsize/8);
+  memset(readfds + oldsize/8, 0, (newsize - oldsize)/8);
+  memset(writefds + oldsize/8, 0, (newsize - oldsize)/8);
+
+  ___free_mem (___fdset_state_readfds (ps));
+  ___free_mem (___fdset_state_writefds (ps));
+  ___fdset_state_readfds (ps) = readfds;
+  ___fdset_state_writefds (ps) = writefds;
+  ___fdset_state_size (ps) = newsize;
 }
 
-static int ___fdset_size ()
+static int ___fdset_size (___processor_state ps)
 {
-  return ___fdset_state_size;
+  return ___fdset_state_size (ps);
 }
 
-static ___poll_fdset ___fdset_readfds ()
+static ___poll_fdset ___fdset_readfds (___processor_state ps)
 {
-  return ___fdset_state_readfds;
+  return ___fdset_state_readfds (ps);
 }
 
-static ___poll_fdset ___fdset_writefds ()
+static ___poll_fdset ___fdset_writefds (___processor_state ps)
 {
-  return ___fdset_state_writefds;
-}
-#endif
-
-/*---------------------------------------------------------------------------*/
-/* Thread-Local state setup*/
-#ifndef ___SINGLE_THREADED_VMS
-void ___setup_io_thread_local_state ___PVOID
-{
-#ifdef USE_poll
-  ___fdset_state_init ();
-#endif
-
+  return ___fdset_state_writefds (ps);
 }
 #endif
 
@@ -810,10 +781,11 @@ ___BOOL for_writing;)
 {
   if (fd >= state->fdset_size)
     {
-      ___fdset_realloc (fd);
-      state->fdset_size = ___fdset_size ();
-      state->readfds = ___fdset_readfds ();
-      state->writefds = ___fdset_writefds ();
+      ___processor_state ps = ___PSTATE;
+      ___fdset_realloc (ps, fd);
+      state->fdset_size = ___fdset_size (ps);
+      state->readfds = ___fdset_readfds (ps);
+      state->writefds = ___fdset_writefds (ps);
     }
 
   state->pollfds[state->pollfd_count].fd = fd;
@@ -855,14 +827,17 @@ HANDLE wait_obj;)
 
 
 ___SCMOBJ ___device_select
-   ___P((___device **devs,
+   ___P((___processor_state ___ps,
+         ___device **devs,
          int nb_read_devs,
          int nb_write_devs,
          ___time timeout),
-        (devs,
+        (___ps,
+         devs,
          nb_read_devs,
          nb_write_devs,
          timeout)
+___processor_state *___ps;
 ___device **devs;
 int nb_read_devs;
 int nb_write_devs;
@@ -906,11 +881,10 @@ ___time timeout;)
 
 #ifdef USE_poll
 
-  ___fdset_alloc ();
   state.pollfd_count = 0;
-  state.fdset_size = ___fdset_size ();
-  state.readfds = ___fdset_readfds ();
-  state.writefds = ___fdset_writefds ();
+  state.fdset_size = ___fdset_size (___ps);
+  state.readfds = ___fdset_readfds (___ps);
+  state.writefds = ___fdset_writefds (___ps);
   ___FD_ZERO (state.readfds, state.fdset_size);
   ___FD_ZERO (state.writefds, state.fdset_size);
 
@@ -1580,6 +1554,7 @@ ___device *self;)
 
   ___device_remove_from_group (self);
 
+  ___processor_state ps = ___PSTATE;
   for (;;)
     {
       e = ___device_close (self, ___DIRECTION_RD);
@@ -1589,7 +1564,7 @@ ___device *self;)
         return e;
 
       devs[0] = self;
-      e = ___device_select (devs, 1, 0, ___time_mod.time_pos_infinity);
+      e = ___device_select (ps, devs, 1, 0, ___time_mod.time_pos_infinity);
       if (e != ___FIX(___NO_ERR))
         return e;
     }
@@ -1603,7 +1578,7 @@ ___device *self;)
         return e;
 
       devs[0] = self;
-      e = ___device_select (devs, 0, 1, ___time_mod.time_pos_infinity);
+      e = ___device_select (ps, devs, 0, 1, ___time_mod.time_pos_infinity);
       if (e != ___FIX(___NO_ERR))
         return e;
     }
@@ -9952,6 +9927,8 @@ ___SCMOBJ timeout;)
   ___SCMOBJ e;
   ___time to;
 
+  ___processor_state ps = ___PSTATE; /* this should be passed as argument */
+
   if (timeout == ___FAL)
     to = ___time_mod.time_neg_infinity;
   else if (timeout == ___TRU)
@@ -9961,7 +9938,7 @@ ___SCMOBJ timeout;)
 
   if (___FALSEP(devices))
     {
-      e = ___device_select (NULL, 0, 0, to);
+      e = ___device_select (ps, NULL, 0, 0, to);
     }
   else
     {
@@ -10015,7 +9992,7 @@ ___SCMOBJ timeout;)
           i++;
         }
 
-      e = ___device_select (devs, read_pos, MAX_CONDVARS-write_pos, to);
+      e = ___device_select (ps, devs, read_pos, MAX_CONDVARS-write_pos, to);
 
       i = 0;
 
@@ -10296,6 +10273,10 @@ ___SCMOBJ ___setup_io_pstate
 ___processor_state ___ps;)
 {
   ___SCMOBJ e = ___FIX(___NO_ERR);
+
+#ifdef USE_poll
+  ___fdset_state_init (___ps);
+#endif
 
 #ifdef USE_ASYNC_DEVICE_SELECT_ABORT
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -82,7 +82,7 @@ static void ___fdset_realloc (int fd)
 {
   int oldsize = ___fdset_state_size;
   int newsize = oldsize;
-  while (newsize < fd)
+  while (newsize <= fd)
     {
       newsize = newisze * 2;
     }
@@ -797,7 +797,7 @@ ___device_select_state *state;
 int fd;
 ___BOOL for_writing;)
 {
-  if (fd > state->fdset_size)
+  if (fd >= state->fdset_size)
     {
       ___fdset_realloc (fd);
       state->fdset_size = ___fdset_size ();

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -165,6 +165,9 @@ typedef struct ___device_select_state_struct
 #endif
   } ___device_select_state;
 
+#ifndef ___SINGLE_THREADED_VMS
+extern void ___setup_io_thread_local_state ___PVOID;
+#endif
 
 extern void ___device_select_add_relative_timeout
    ___P((___device_select_state *state,

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -105,21 +105,21 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_ZERO(set, sz)                        \
   memset ((set), 0, sz/8)
 #define ___FD_SET(fd, set)                    \
-  ((set)->fds[___FD_ELT (fd)] |= ___FD_MASK (fd))
+  ((set)[___FD_ELT (fd)] |= ___FD_MASK (fd))
 #define ___FD_CLR(fd, set)                    \
-  ((set)->fds[___FD_ELT (fd)] &= ~___FD_MASK (fd))
+  ((set)[___FD_ELT (fd)] &= ~___FD_MASK (fd))
 #define ___FD_ISSET(fd, set)                  \
-  ((set)->fds[___FD_ELT (fd)] & ___FD_MASK (fd))
+  ((set)[___FD_ELT (fd)] & ___FD_MASK (fd))
 
-typedef ___fdbits *___poll_fd_set;
+typedef ___fdbits *___poll_fdset;
 
 #endif
 
 #ifdef USE_select
-#define ___FD_ZERO  FD_ZERO
-#define ___FD_ISSET FD_ISSET
-#define ___FD_CLR   FD_CLR
-#define ___FD_SET   FD_SET
+#define ___FD_ZERO(set)      FD_ZERO(&set)
+#define ___FD_ISSET(fd, set) FD_ISSET(fd, &set)
+#define ___FD_CLR(fd, set)   FD_CLR(fd, &set)
+#define ___FD_SET(fd, set)   FD_SET(fd, &set)
 #endif
 
 typedef struct ___device_select_state_struct
@@ -146,8 +146,8 @@ typedef struct ___device_select_state_struct
     int pollfd_count;
     /* active set bitmaps */
     int fdset_size;
-    ___poll_fd_set readfds;
-    ___poll_fd_set writefds;
+    ___poll_fdset readfds;
+    ___poll_fdset writefds;
 #endif
 
 #endif

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -102,8 +102,8 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_ELT(fd) ((fd) / ___FDBITS)
 #define ___FD_MASK(fd) ((___fdbits) 1 << ((fd) % ___FDBITS))
 
-#define ___FD_ZERO(set)                       \
-  memset ((set), 0, sizeof (___poll_fd_set))
+#define ___FD_ZERO(set, sz)                        \
+  memset ((set), 0, sz / ___FDBITS)
 #define ___FD_SET(fd, set)                    \
   ((set)->fds[___FD_ELT (fd)] |= ___FD_MASK (fd))
 #define ___FD_CLR(fd, set)                    \
@@ -111,9 +111,7 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_ISSET(fd, set)                  \
   ((set)->fds[___FD_ELT (fd)] & ___FD_MASK (fd))
 
-typedef struct ___poll_fd_set {
-  ___fdbits fds[MAX_POLLFDS / ___FDBITS];
-} ___poll_fd_set;
+typedef ___fdbits *___poll_fd_set;
 
 #endif
 
@@ -147,6 +145,7 @@ typedef struct ___device_select_state_struct
     struct pollfd pollfds[MAX_POLLFDS];
     int pollfd_count;
     /* active set bitmaps */
+    int fdset_size;
     ___poll_fd_set readfds;
     ___poll_fd_set writefds;
 #endif

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -165,10 +165,6 @@ typedef struct ___device_select_state_struct
 #endif
   } ___device_select_state;
 
-#ifndef ___SINGLE_THREADED_VMS
-extern void ___setup_io_thread_local_state ___PVOID;
-#endif
-
 extern void ___device_select_add_relative_timeout
    ___P((___device_select_state *state,
          int i,
@@ -621,7 +617,8 @@ extern ___SCMOBJ ___device_stream_setup
         ());
 
 extern ___SCMOBJ ___device_select
-   ___P((___device **devs,
+   ___P((___processor_state ___ps,
+         ___device **devs,
          int nb_read_devs,
          int nb_write_devs,
          ___time timeout),

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -103,7 +103,7 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_MASK(fd) ((___fdbits) 1 << ((fd) % ___FDBITS))
 
 #define ___FD_ZERO(set, sz)                        \
-  memset ((set), 0, sz / ___FDBITS)
+  memset ((set), 0, sz/8)
 #define ___FD_SET(fd, set)                    \
   ((set)->fds[___FD_ELT (fd)] |= ___FD_MASK (fd))
 #define ___FD_CLR(fd, set)                    \

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -49,7 +49,9 @@ void *param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
 
+#ifndef ___SINGLE_THREADED_VMS
   ___setup_thread_local_state ();
+#endif
 
   thread->start_fn (thread);
 
@@ -70,7 +72,9 @@ LPVOID param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
 
+#ifndef ___SINGLE_THREADED_VMS
   ___setup_thread_local_state ();
+#endif
 
   thread->start_fn (thread);
 

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -30,13 +30,6 @@ ___thread_module ___thread_mod =
 };
 
 
-#ifndef ___SINGLE_THREADED_VMS
-void ___setup_thread_local_state ___PVOID
-{
-  ___setup_io_thread_local_state ();
-}
-#endif
-
 /*---------------------------------------------------------------------------*/
 
 
@@ -48,10 +41,6 @@ ___HIDDEN void *start_pthread_thread
 void *param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
-
-#ifndef ___SINGLE_THREADED_VMS
-  ___setup_thread_local_state ();
-#endif
 
   thread->start_fn (thread);
 
@@ -71,10 +60,6 @@ ___HIDDEN DWORD WINAPI start_win32_thread
 LPVOID param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
-
-#ifndef ___SINGLE_THREADED_VMS
-  ___setup_thread_local_state ();
-#endif
 
   thread->start_fn (thread);
 

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -35,10 +35,6 @@ ___thread_module ___thread_mod =
 
 #ifdef ___USE_POSIX_THREAD_SYSTEM
 
-#ifdef USE_poll
-extern void ___fdset_state_init ();
-#endif 
-
 ___HIDDEN void *start_pthread_thread
    ___P((void *param),
         (param)
@@ -47,6 +43,7 @@ void *param;)
   ___thread *thread = ___CAST(___thread*,param);
 
 #ifdef USE_poll
+  extern void ___fdset_state_init ();
   ___fdset_state_init ();
 #endif
   

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -46,7 +46,7 @@ void *param;)
   extern void ___fdset_state_init ();
   ___fdset_state_init ();
 #endif
-  
+
   thread->start_fn (thread);
 
   return 0;

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -30,6 +30,13 @@ ___thread_module ___thread_mod =
 };
 
 
+#ifndef ___SINGLE_THREADED_VMS
+void ___setup_thread_local_state ___PVOID
+{
+  ___setup_io_thread_local_state ();
+}
+#endif
+
 /*---------------------------------------------------------------------------*/
 
 
@@ -42,10 +49,7 @@ void *param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
 
-#ifdef USE_poll
-  extern void ___fdset_state_init ();
-  ___fdset_state_init ();
-#endif
+  ___setup_thread_local_state ();
 
   thread->start_fn (thread);
 
@@ -65,6 +69,8 @@ ___HIDDEN DWORD WINAPI start_win32_thread
 LPVOID param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
+
+  ___setup_thread_local_state ();
 
   thread->start_fn (thread);
 

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -35,6 +35,9 @@ ___thread_module ___thread_mod =
 
 #ifdef ___USE_POSIX_THREAD_SYSTEM
 
+#ifdef USE_poll
+extern void ___fdset_state_init ();
+#endif 
 
 ___HIDDEN void *start_pthread_thread
    ___P((void *param),
@@ -43,6 +46,10 @@ void *param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
 
+#ifdef USE_poll
+  ___fdset_state_init ();
+#endif
+  
   thread->start_fn (thread);
 
   return 0;

--- a/lib/os_thread.h
+++ b/lib/os_thread.h
@@ -95,6 +95,9 @@ extern ___SCMOBJ ___setup_thread_module ___PVOID;
 
 extern void ___cleanup_thread_module ___PVOID;
 
+#ifndef ___SINGLE_THREADED_VMS
+extern void ___setup_thread_local_state ___PVOID;
+#endif
 
 /*---------------------------------------------------------------------------*/
 

--- a/lib/os_thread.h
+++ b/lib/os_thread.h
@@ -95,10 +95,6 @@ extern ___SCMOBJ ___setup_thread_module ___PVOID;
 
 extern void ___cleanup_thread_module ___PVOID;
 
-#ifndef ___SINGLE_THREADED_VMS
-extern void ___setup_thread_local_state ___PVOID;
-#endif
-
 /*---------------------------------------------------------------------------*/
 
 

--- a/lib/os_tty.c
+++ b/lib/os_tty.c
@@ -2332,7 +2332,7 @@ ___device_tty *self;)
           }
 
 #endif
-	  
+
 	  if (byte_avail ==  ___NBELEMS(d->output_byte) - d->output_byte_hi)
 	    break;  /* not enough space for a full multibyte character, first flush what we have */
 

--- a/lib/os_tty.c
+++ b/lib/os_tty.c
@@ -7531,7 +7531,7 @@ ___device_select_state *state;)
     {
 #ifdef USE_POSIX
 
-      if (d->fd < 0 || ___FD_ISSET(d->fd, &state->writefds))
+      if (d->fd < 0 || ___FD_ISSET(d->fd, state->writefds))
         state->devs[i] = NULL;
 
 #endif
@@ -7547,7 +7547,7 @@ ___device_select_state *state;)
     {
 #ifdef USE_POSIX
 
-      if (d->fd < 0 || ___FD_ISSET(d->fd, &state->readfds))
+      if (d->fd < 0 || ___FD_ISSET(d->fd, state->readfds))
         state->devs[i] = NULL;
 
 #endif

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -628,7 +628,7 @@ ___WORD target_processor_count;)
   extern void ___fdset_state_init ();
   ___fdset_state_init ();
 #endif
-  
+
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */
   ___sync_op_struct sop;

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -624,6 +624,11 @@ ___WORD target_processor_count;)
 
 #ifndef ___SINGLE_THREADED_VMS
 
+#ifdef USE_poll
+  extern void ___fdset_state_init ();
+  ___fdset_state_init ();
+#endif
+  
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */
   ___sync_op_struct sop;

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -624,8 +624,6 @@ ___WORD target_processor_count;)
 
 #ifndef ___SINGLE_THREADED_VMS
 
-  ___setup_thread_local_state ();
-
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */
   ___sync_op_struct sop;

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -624,10 +624,7 @@ ___WORD target_processor_count;)
 
 #ifndef ___SINGLE_THREADED_VMS
 
-#ifdef USE_poll
-  extern void ___fdset_state_init ();
-  ___fdset_state_init ();
-#endif
+  ___setup_thread_local_state ();
 
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */


### PR DESCRIPTION
Implements dynamically sized fdsets for poll, so that we can scale to arbitrary numbers of file descriptors without having to manually increase the compile-time constant `MAX_POLLFDS`.
This solves the issue of crashing on an `___FD_SET` (or worse, silently corrupting) when the file descriptor is higher than `MAX_POLLFDS` by checking and resizing as needed.

Note that it's not intended to side-step the limit on the number of file descriptors that can be concurently polled (that's specified by `MAX_CONDVARS`), but to allow us to have arbitrary numbers of open file descriptors without fear of crashing in the next file we open and try to read.