### PR TITLE
[WIP] Implement raw devices and Dynamic Pollsets

### DIFF
--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -8381,6 +8381,15 @@ typedef struct ___sync_op_struct
     ___VOLATILE ___WORD arg[2];   /* arguments of the operation */
   } ___sync_op_struct;
 
+/* fdset state */
+#ifdef USE_POLL_FOR_SELECT
+typedef struct ___fdset_state_struct {
+  int size;
+  void *readfds;
+  void *writefds;
+} ___fdset_state;
+#endif
+
 /* Processor structure */
 
 typedef struct ___processor_state_struct
@@ -8462,6 +8471,10 @@ typedef struct ___processor_state_struct
     ___MUTEX_DECL(sync_mut)
     ___CONDVAR_DECL(sync_cv)
 
+#endif
+
+#ifdef USE_POLL_FOR_SELECT
+    ___fdset_state fdset_state;
 #endif
   } ___processor_state_struct;
 

--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -8146,6 +8146,15 @@ typedef struct ___rc_header_struct
     ___SCMOBJ data; /* needed for C closures */
   } ___rc_header;
 
+/* fdset state */
+#ifdef USE_POLL_FOR_SELECT
+typedef struct ___fdset_state_struct {
+  int size;
+  void *readfds;
+  void *writefds;
+} ___fdset_state;
+#endif
+
 typedef struct ___pstate_os_struct {
 
   /*
@@ -8157,6 +8166,11 @@ typedef struct ___pstate_os_struct {
 #else
   ___half_duplex_pipe select_abort; /* POSIX self-pipe */
 #endif
+  
+#ifdef USE_POLL_FOR_SELECT
+    ___fdset_state fdset_state;
+#endif
+
 
 } ___pstate_os;
 
@@ -8381,15 +8395,6 @@ typedef struct ___sync_op_struct
     ___VOLATILE ___WORD arg[2];   /* arguments of the operation */
   } ___sync_op_struct;
 
-/* fdset state */
-#ifdef USE_POLL_FOR_SELECT
-typedef struct ___fdset_state_struct {
-  int size;
-  void *readfds;
-  void *writefds;
-} ___fdset_state;
-#endif
-
 /* Processor structure */
 
 typedef struct ___processor_state_struct
@@ -8471,10 +8476,6 @@ typedef struct ___processor_state_struct
     ___MUTEX_DECL(sync_mut)
     ___CONDVAR_DECL(sync_cv)
 
-#endif
-
-#ifdef USE_POLL_FOR_SELECT
-    ___fdset_state fdset_state;
 #endif
   } ___processor_state_struct;
 

--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -150,6 +150,7 @@
 (##define-macro (macro-tty-kind)         (+ 15 64))
 (##define-macro (macro-serial-kind)      (+ 15 128))
 (##define-macro (macro-tcp-client-kind)  (+ 15 256))
+(##define-macro (macro-raw-device-kind)  (+ 15 512))
 (##define-macro (macro-tcp-server-kind)  (+ 1 512))
 (##define-macro (macro-directory-kind)   (+ 1 1024))
 (##define-macro (macro-event-queue-kind) (+ 1 2048))
@@ -528,6 +529,17 @@
 
 (##define-macro (macro-tcp-client-port? obj)
   `(##port-of-kind? ,obj (macro-tcp-client-kind)))
+
+;;; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+;;; Representation of raw device ports.
+
+(define-check-type raw-device-port 'raw-device-port
+  macro-raw-device-port?)
+
+(##define-macro (macro-raw-device-port? obj)
+  `(##port-of-kind? ,obj (macro-raw-device-kind)))
+
 
 ;;; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -545,7 +545,7 @@
   unprintable:
 
   extender: define-type-of-raw-device-port
-  
+
   rdevice-condvar
   wdevice-condvar
   fd

--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -534,6 +534,23 @@
 
 ;;; Representation of raw device ports.
 
+(define-type-of-port raw-device-port
+  id: f55e3678-0414-63d0-3fda-68b9bc518bca
+  type-exhibitor: macro-type-raw-device-port
+  constructor: macro-make-raw-device-port
+  implementer: implement-type-raw-device-port
+  macros:
+  prefix: macro-
+  opaque:
+  unprintable:
+
+  extender: define-type-of-raw-device-port
+  
+  rdevice-condvar
+  wdevice-condvar
+  fd
+)
+
 (define-check-type raw-device-port 'raw-device-port
   macro-raw-device-port?)
 

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8254,6 +8254,33 @@
         (macro-dynamic-bind output-port port thunk)))))
 
 ;;;----------------------------------------------------------------------------
+(define-prim (##open-raw-device
+              direction
+              name
+              fd
+              settings)
+  (define (fail)
+    (##fail-check-settings 4 ##open-raw-device direction name fd settings))
+  
+  (##make-psettings
+   direction
+   '(direction:)
+   settings
+   fail
+   (lambda (psettings)
+     (let ((device
+            (##os-device-open-raw
+             fd
+             (##psettings->device-flags psettings))))
+       (if (##fixnum? device)
+         (##exit-with-err-code device)
+         (and device
+              (##make-device-port-from-single-device
+               name
+               device
+               psettings)))))))
+
+;;;----------------------------------------------------------------------------
 
 (define-prim (##open-predefined
               direction

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8257,15 +8257,14 @@
 (define-prim (##open-raw-device
               direction
               name
-              fd
-              settings)
+              fd)
   (define (fail)
-    (##fail-check-settings 4 ##open-raw-device direction name fd settings))
-  
+    (##fail-check-settings 1 ##open-raw-device direction name fd))
+
   (##make-psettings
    direction
-   '(direction:)
-   settings
+   '()
+   '()
    fail
    (lambda (psettings)
      (let ((device
@@ -8274,11 +8273,111 @@
              (##psettings->device-flags psettings))))
        (if (##fixnum? device)
          (##exit-with-err-code device)
-         (and device
-              (##make-device-port-from-single-device
-               name
-               device
-               psettings)))))))
+         (##make-raw-device-port device fd name direction))))))
+
+(define-prim (##make-raw-device-port device fd uname direction)
+  (let ((mutex
+         (macro-make-port-mutex))
+        (rkind
+         (if (or (##eq? direction (macro-direction-in))
+                 (##eq? direction (macro-direction-inout)))
+           (macro-raw-device-kind)
+           (macro-none-kind)))
+        (wkind
+         (if (or (##eq? direction (macro-direction-out))
+                 (##eq? direction (macro-direction-inout)))
+           (macro-raw-device-kind)
+           (macro-none-kind)))
+        (roptions
+         0)
+        (rtimeout
+         #t)
+        (rtimeout-thunk
+         #f)
+        (woptions
+         0)
+        (wtimeout
+         #t)
+        (wtimeout-thunk
+         #f)
+        (rdevice-condvar
+         (and (or (##eq? direction (macro-direction-in))
+                  (##eq? direction (macro-direction-inout)))
+              (##make-rdevice-condvar device)))
+        (wdevice-condvar
+         (and (or (##eq? direction (macro-direction-out))
+                  (##eq? direction (macro-direction-inout)))
+              (##make-wdevice-condvar device)))
+        (uname (or uname 'raw-device)))
+
+    (define (name port)
+
+      ;; It is assumed that the thread **does not** have exclusive
+      ;; access to the port.
+
+      (##declare (not interrupts-enabled))
+      (##list uname (macro-raw-device-port-fd port)))
+
+    (define read-datum #f)
+
+    (define write-datum #f)
+
+    (define newline #f)
+
+    (define force-output #f)
+
+    (define set-rtimeout #f)
+
+    (define set-wtimeout #f)
+
+    (define (close port prim arg1)
+
+      ;; It is assumed that the thread **does not** have exclusive
+      ;; access to the port.
+
+      (##declare (not interrupts-enabled))
+
+      (macro-port-mutex-lock! port) ;; get exclusive access to port
+
+      (let ((result
+             (##close-device
+              port
+              (macro-raw-device-port-rdevice-condvar port)
+              (macro-raw-device-port-wdevice-condvar port)
+              prim)))
+        (macro-port-mutex-unlock! port)
+        (if (##fixnum? result)
+            (##raise-os-io-exception port #f result prim arg1)
+            result)))
+
+    (let ((port
+           (macro-make-raw-device-port
+            mutex
+            rkind
+            wkind
+            name
+            read-datum
+            write-datum
+            newline
+            force-output
+            close
+            roptions
+            rtimeout
+            rtimeout-thunk
+            set-rtimeout
+            woptions
+            wtimeout
+            wtimeout-thunk
+            set-wtimeout
+            #f ;; io-exception-handler
+            rdevice-condvar
+            wdevice-condvar
+            fd)))
+      (if rdevice-condvar
+        (##io-condvar-port-set! rdevice-condvar port))
+      (if wdevice-condvar
+        (##io-condvar-port-set! wdevice-condvar port))
+      port)))
 
 ;;;----------------------------------------------------------------------------
 

--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -4279,6 +4279,12 @@ end-of-code
             scheme-object   ;; device
    "___os_device_stream_open_process"))
 
+(define-prim ##os-device-open-raw
+  (c-lambda (scheme-object  ;; fd
+        scheme-object) ;; flags
+       scheme-object   ;; device
+   "___os_device_raw_open"))
+
 (define-prim ##os-device-process-pid
   (c-lambda (scheme-object) ;; dev
             scheme-object   ;; pid (fixnum)

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -109,6 +109,8 @@ static ___poll_fdset ___fdset_writefds (___processor_state ps)
   return ___fdset_state_writefds (ps);
 }
 
+#endif
+
 int ___fdset_resize_pstate
    ___P((___processor_state ___ps,
          int fd),
@@ -117,10 +119,13 @@ int ___fdset_resize_pstate
 ___processor_state ___ps;
 int fd;)
 {
+#ifdef USE_poll
   return ___fdset_realloc (___ps, fd);
+#endf
+  return 0;
 }
 
-#endif
+
 
 /*---------------------------------------------------------------------------*/
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -84,27 +84,27 @@ static void ___fdset_realloc (int fd)
   int newsize = oldsize;
   while (newsize <= fd)
     {
-      newsize = newisze * 2;
+      newsize = newsize * 2;
     }
 
   ___fdset_state_readfds = realloc (___fdset_state_readfds, newsize/8);
   ___fdset_state_writefds = realloc (___fdset_state_writefds, newsize/8);
   ___fdset_state_size = newsize;
-  memset(___fdset_state_readfds + oldsize/8, 0, (newsize - oldsize)/8)
+  memset(___fdset_state_readfds + oldsize/8, 0, (newsize - oldsize)/8);
   memset(___fdset_state_writefds + oldsize/8, 0, (newsize - oldsize)/8);
 }
 
-static void ___fdset_size ()
+static int ___fdset_size ()
 {
   return ___fdset_state_size;
 }
 
-static void ___fdset_readfds ()
+static ___poll_fdset ___fdset_readfds ()
 {
   return ___fdset_state_readfds;
 }
 
-static void ___fdset_writefds ()
+static ___poll_fdset ___fdset_writefds ()
 {
   return ___fdset_state_writefds;
 }
@@ -774,9 +774,9 @@ int fd;
 ___BOOL for_writing;)
 {
   if (for_writing)
-    ___FD_SET(fd, &state->writefds);
+    ___FD_SET(fd, state->writefds);
   else
-    ___FD_SET(fd, &state->readfds);
+    ___FD_SET(fd, state->readfds);
 
   if (fd >= state->highest_fd_plus_1)
     state->highest_fd_plus_1 = fd+1;
@@ -1243,7 +1243,7 @@ ___time timeout;)
 
 #ifdef USE_ASYNC_DEVICE_SELECT_ABORT
 
-  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, &state.readfds))
+  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, state.readfds))
     {
       /* self-pipe has available data to read, discard all of it */
 
@@ -1422,7 +1422,7 @@ ___time timeout;)
 
 #ifdef USE_select_or_poll
 
-  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, &state.readfds))
+  if (___FD_ISSET(___PSTATE->os.select_abort.reading_fd, state.readfds))
     {
       /* self-pipe has available data to read, discard all of it */
 
@@ -3002,12 +3002,12 @@ ___device_select_state *state;)
 
       if (for_writing)
         {
-          if (d->fd_wr < 0 || ___FD_ISSET(d->fd_wr, &state->writefds))
+          if (d->fd_wr < 0 || ___FD_ISSET(d->fd_wr, state->writefds))
             state->devs[i] = NULL;
         }
       else
         {
-          if (d->fd_rd < 0 || ___FD_ISSET(d->fd_rd, &state->readfds))
+          if (d->fd_rd < 0 || ___FD_ISSET(d->fd_rd, state->readfds))
             state->devs[i] = NULL;
         }
 
@@ -4966,8 +4966,8 @@ ___device_select_state *state;)
 
       if (d->try_connect_again != 0 ||
           (for_writing
-           ? ___FD_ISSET(d->s, &state->writefds)
-           : ___FD_ISSET(d->s, &state->readfds)))
+           ? ___FD_ISSET(d->s, state->writefds)
+           : ___FD_ISSET(d->s, state->readfds)))
         {
           d->connect_done = 1;
           state->devs[i] = NULL;
@@ -5739,7 +5739,7 @@ ___device_select_state *state;)
     {
 #ifdef USE_POSIX
 
-      if (___FD_ISSET(d->s, &state->readfds))
+      if (___FD_ISSET(d->s, state->readfds))
         state->devs[i] = NULL;
 
 #endif
@@ -6677,8 +6677,8 @@ ___device_select_state *state;)
 #ifdef USE_POSIX
 
       if (for_writing
-           ? ___FD_ISSET(d->fd, &state->writefds)
-           : ___FD_ISSET(d->fd, &state->readfds))
+           ? ___FD_ISSET(d->fd, state->writefds)
+           : ___FD_ISSET(d->fd, state->readfds))
         state->devs[i] = NULL;
 
 #endif

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -110,6 +110,17 @@ static ___poll_fdset ___fdset_writefds ()
 }
 #endif
 
+/*---------------------------------------------------------------------------*/
+/* Thread-Local state setup*/
+#ifndef ___SINGLE_THREADED_VMS
+void ___setup_io_thread_local_state ___PVOID
+{
+#ifdef USE_poll
+  ___fdset_state_init ();
+#endif
+
+}
+#endif
 
 /*---------------------------------------------------------------------------*/
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9071,14 +9071,7 @@ ___device_select_state *state;)
 
   if (stage == ___STAGE_OPEN)
     {
-      if (for_writing)
-        {
-          ___device_select_add_fd (state, d->fd, 0);
-        }
-      else
-        {
-          ___device_select_add_fd (state, d->fd, 0);
-        }
+      ___device_select_add_fd (state, d->fd, for_writing);
     }
 
   return ___FIX(___NO_ERR);

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9084,7 +9084,7 @@ ___device_select_state *state;)
     state->devs[i] = NULL;
   else if (___FD_ISSET(d->fd, state->readfds))
     state->devs[i] = NULL;
-  
+
   return ___FIX(___NO_ERR);
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9069,11 +9069,22 @@ ___device_select_state *state;)
                ? d->base.write_stage
                : d->base.read_stage);
 
-  if (stage == ___STAGE_OPEN)
+  if (pass == ___SELECT_PASS_1)
     {
-      ___device_select_add_fd (state, d->fd, for_writing);
+      if (stage != ___STAGE_OPEN)
+        state->timeout = ___time_mod.time_neg_infinity;
+      else
+        ___device_select_add_fd (state, d->fd, for_writing);
+
+      return ___FIX(___SELECT_SETUP_DONE);
     }
 
+  /* pass == ___SELECT_PASS_CHECK */
+  if (stage != ___STAGE_OPEN)
+    state->devs[i] = NULL;
+  else if (___FD_ISSET(d->fd, state->readfds))
+    state->devs[i] = NULL;
+  
   return ___FIX(___NO_ERR);
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -40,9 +40,9 @@ ___io_module ___io_mod =
 /* poll dynamic fdset memory management. */
 
 #ifdef USE_poll
-#define ___fdset_state_size(ps)     ps->fdset_state.size
-#define ___fdset_state_readfds(ps)  ps->fdset_state.readfds
-#define ___fdset_state_writefds(ps) ps->fdset_state.writefds
+#define ___fdset_state_size(ps)     ps->os.fdset_state.size
+#define ___fdset_state_readfds(ps)  ps->os.fdset_state.readfds
+#define ___fdset_state_writefds(ps) ps->os.fdset_state.writefds
 
 void ___fdset_state_init (___processor_state ps)
 {

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -46,8 +46,13 @@ ___io_module ___io_mod =
 
 void ___fdset_state_init (___processor_state ps)
 {
-  ___fdset_state_readfds (ps) = ___ALLOC_MEM (MAX_CONDVARS/8);
-  ___fdset_state_writefds (ps) = ___ALLOC_MEM (MAX_CONDVARS/8);
+  void *readfds, *writefds;
+  readfds  = ___ALLOC_MEM (MAX_CONDVARS/8);
+  writefds = ___ALLOC_MEM (MAX_CONDVARS/8);
+  memset (readfds, 0, MAX_CONDVARS/8);
+  memset (writefds, 0, MAX_CONDVARS/8);
+  ___fdset_state_readfds (ps) = readfds;
+  ___fdset_state_writefds (ps) = writefds;
   ___fdset_state_size (ps) = MAX_CONDVARS;
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -121,7 +121,7 @@ int fd;)
 {
 #ifdef USE_poll
   return ___fdset_realloc (___ps, fd);
-#endf
+#endif
   return 0;
 }
 
@@ -813,15 +813,6 @@ ___device_select_state *state;
 int fd;
 ___BOOL for_writing;)
 {
-  if (fd >= state->fdset_size)
-    {
-      ___processor_state ps = ___PSTATE;
-      ___fdset_realloc (ps, fd);
-      state->fdset_size = ___fdset_size (ps);
-      state->readfds = ___fdset_readfds (ps);
-      state->writefds = ___fdset_writefds (ps);
-    }
-
   state->pollfds[state->pollfd_count].fd = fd;
   if (for_writing)
     state->pollfds[state->pollfd_count].events = POLLOUT;
@@ -3303,6 +3294,12 @@ int fd_wr;
 int direction;)
 {
   ___device_pipe *d;
+  ___processor_state ps = ___PSTATE;
+
+  if (___fdset_resize (ps, fd_rd))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
+  if (___fdset_resize (ps, fd_wr))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
 
   d = ___CAST(___device_pipe*,
               ___ALLOC_MEM(sizeof (___device_pipe)));
@@ -3672,6 +3669,12 @@ int fd_stdout;
 int direction;)
 {
   ___device_process *d;
+  ___processor_state ps = ___PSTATE;
+
+  if (___fdset_resize (ps, fd_stdin))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
+  if (___fdset_resize (ps, fd_stdout))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
 
   d = ___CAST(___device_process*,
               ___ALLOC_MEM(sizeof (___device_process)));
@@ -5485,6 +5488,13 @@ int direction;)
   ___SCMOBJ e;
   ___device_tcp_client *d;
 
+#ifdef USE_POSIX
+  ___processor_state ps = ___PSTATE;
+
+  if (___fdset_resize (ps, s))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
+#endif
+
   d = ___CAST(___device_tcp_client*,
               ___ALLOC_MEM(sizeof (___device_tcp_client)));
 
@@ -5843,6 +5853,16 @@ ___tls_context *tls_context;)
       CLOSE_SOCKET(s); /* ignore error */
       return e;
     }
+
+#ifdef USE_POSIX
+  ___processor_state ps = ___PSTATE;
+
+  if (___fdset_resize (ps, s))
+    {
+      CLOSE_SOCKET(s);
+      return ___FIX(___HEAP_OVERFLOW_ERR);
+    }
+#endif
 
   d = ___CAST(___device_tcp_server*,
               ___ALLOC_MEM(sizeof (___device_tcp_server)));
@@ -7181,6 +7201,10 @@ int fd;
 int direction;)
 {
   ___device_file *d;
+  ___processor_state ps = ___PSTATE;
+
+  if (___fdset_resize (ps, fd))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
 
   d = ___CAST(___device_file*,
               ___ALLOC_MEM(sizeof (___device_file)));
@@ -9153,6 +9177,10 @@ int fd;
 int direction;)
 {
   ___device_raw *d;
+  ___processor_state ps = ___PSTATE;
+
+  if (___fdset_resize (ps, fd))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
 
   d = ___CAST(___device_raw*,
               ___ALLOC_MEM(sizeof (___device_raw)));

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -44,6 +44,8 @@ ___io_module ___io_mod =
 #define ___fdset_state_readfds(ps)  ps->os.fdset_state.readfds
 #define ___fdset_state_writefds(ps) ps->os.fdset_state.writefds
 
+static int ___fdset_heap_overflow;
+
 static void ___fdset_state_init (___processor_state ps)
 {
   void *readfds, *writefds;
@@ -89,8 +91,8 @@ static int ___fdset_realloc (___processor_state ps, int fd)
   return 0;
 
  error:
-  free (readfds);
-  free (writefds);
+  ___free_mem (readfds);
+  ___free_mem (writefds);
   return 1;
 }
 
@@ -111,7 +113,7 @@ static ___poll_fdset ___fdset_writefds (___processor_state ps)
 
 #endif
 
-int ___fdset_resize_pstate
+void ___fdset_resize_pstate
    ___P((___processor_state ___ps,
          int fd),
         (___ps,
@@ -120,11 +122,26 @@ ___processor_state ___ps;
 int fd;)
 {
 #ifdef USE_poll
-  return ___fdset_realloc (___ps, fd);
+  if (___fdset_realloc (___ps, fd))
+    ___fdset_heap_overflow = 1;
 #endif
-  return 0;
 }
 
+void ___fdset_resize_heap_overflow_clear ___PVOID
+{
+#ifdef USE_poll
+  ___fdset_heap_overflow = 0;
+#endif
+}
+
+int ___fdset_resize_heap_overflow ___PVOID
+{
+#ifdef USE_poll
+  return ___fdset_heap_overflow;
+#endif
+
+  return 0;
+}
 
 
 /*---------------------------------------------------------------------------*/

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9020,7 +9020,7 @@ ___HIDDEN ___SCMOBJ ___device_raw_close_virt
 {
   ___device_raw *d = ___CAST(___device_raw*,self);
   int is_not_closed = 0;
-  
+
   if (d->base.read_stage != ___STAGE_CLOSED)
     is_not_closed |= ___DIRECTION_RD;
 
@@ -9034,7 +9034,7 @@ ___HIDDEN ___SCMOBJ ___device_raw_close_virt
     {
       d->base.read_stage = ___STAGE_CLOSED; /* avoid multiple closes */
       d->base.write_stage = ___STAGE_CLOSED;
-      
+
       if (___close_no_EINTR (d->fd) < 0)
         return err_code_from_errno ();
     }
@@ -9129,7 +9129,7 @@ int fd;
 int direction;)
 {
   ___device_raw *d;
-  
+
   d = ___CAST(___device_raw*,
               ___ALLOC_MEM(sizeof (___device_raw)));
 
@@ -9141,7 +9141,7 @@ int direction;)
   d->base.refcount = 1;
   d->base.direction = direction;
   d->base.close_direction = 0; /* prevent closing on errors */
-  
+
   if (direction & ___DIRECTION_RD)
     {
       d->base.read_stage = ___STAGE_OPEN;
@@ -9159,15 +9159,15 @@ int direction;)
     {
       d->base.write_stage = ___STAGE_CLOSED;
     }
-  
+
   d->fd = fd;
 
   device_transfer_close_responsibility (___CAST(___device*,d));
 
   *dev = d;
-  
+
   ___device_add_to_group (dgroup, &d->base);
-  
+
   return ___FIX(___NO_ERR);
 }
 
@@ -9190,7 +9190,7 @@ ___SCMOBJ flags;)
   int fd;
   int fl;
   int direction;
-  
+
   device_translate_flags (___INT(flags),
                           &fl,
                           &direction);

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9007,7 +9007,7 @@ ___HIDDEN int ___device_raw_kind
         (self)
 ___device *self;)
 {
-  return ___RAW_KIND;
+  return ___RAW_DEVICE_KIND;
 }
 
 ___HIDDEN ___SCMOBJ ___device_raw_close_virt

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -887,9 +887,9 @@ ___time timeout;)
 
   state.highest_fd_plus_1 = 0;
 
-  ___FD_ZERO(&state.readfds);
-  ___FD_ZERO(&state.writefds);
-  ___FD_ZERO(&state.exceptfds);
+  ___FD_ZERO(state.readfds);
+  ___FD_ZERO(state.writefds);
+  ___FD_ZERO(state.exceptfds);
 
 #endif
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9161,9 +9161,13 @@ int direction;)
     }
   
   d->fd = fd;
-  
-  *dev = d;
 
+  device_transfer_close_responsibility (___CAST(___device*,d));
+
+  *dev = d;
+  
+  ___device_add_to_group (dgroup, &d->base);
+  
   return ___FIX(___NO_ERR);
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -72,9 +72,9 @@ static void ___fdset_alloc ()
 {
   if (!___fdset_state_size)
     {
-      ___fdset_state_readfds = malloc (MAX_CONDVARS/8);
-      ___fdset_state_writefds = malloc (MAX_CONDVARS/8);
-      ___fdset_state_size = MAX_CONDVARS;
+      ___fdset_state_readfds = malloc (MAX_POLLFDS/8);
+      ___fdset_state_writefds = malloc (MAX_POLLFDS/8);
+      ___fdset_state_size = MAX_POLLFDS;
     }
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -82,7 +82,7 @@ static void ___fdset_realloc (int fd)
 {
   int oldsize = ___fdset_state_size;
   int newsize = oldsize;
-  while (newsize < fd)
+  while (newsize <= fd)
     {
       newsize = newisze * 2;
     }
@@ -797,7 +797,7 @@ ___device_select_state *state;
 int fd;
 ___BOOL for_writing;)
 {
-  if (fd > state->fdset_size)
+  if (fd >= state->fdset_size)
     {
       ___fdset_realloc (fd);
       state->fdset_size = ___fdset_size ();

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -105,21 +105,21 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_ZERO(set, sz)                        \
   memset ((set), 0, sz/8)
 #define ___FD_SET(fd, set)                    \
-  ((set)->fds[___FD_ELT (fd)] |= ___FD_MASK (fd))
+  ((set)[___FD_ELT (fd)] |= ___FD_MASK (fd))
 #define ___FD_CLR(fd, set)                    \
-  ((set)->fds[___FD_ELT (fd)] &= ~___FD_MASK (fd))
+  ((set)[___FD_ELT (fd)] &= ~___FD_MASK (fd))
 #define ___FD_ISSET(fd, set)                  \
-  ((set)->fds[___FD_ELT (fd)] & ___FD_MASK (fd))
+  ((set)[___FD_ELT (fd)] & ___FD_MASK (fd))
 
-typedef ___fdbits *___poll_fd_set;
+typedef ___fdbits *___poll_fdset;
 
 #endif
 
 #ifdef USE_select
-#define ___FD_ZERO  FD_ZERO
-#define ___FD_ISSET FD_ISSET
-#define ___FD_CLR   FD_CLR
-#define ___FD_SET   FD_SET
+#define ___FD_ZERO(set)      FD_ZERO(&set)
+#define ___FD_ISSET(fd, set) FD_ISSET(fd, &set)
+#define ___FD_CLR(fd, set)   FD_CLR(fd, &set)
+#define ___FD_SET(fd, set)   FD_SET(fd, &set)
 #endif
 
 typedef struct ___device_select_state_struct
@@ -146,8 +146,8 @@ typedef struct ___device_select_state_struct
     int pollfd_count;
     /* active set bitmaps */
     int fdset_size;
-    ___poll_fd_set readfds;
-    ___poll_fd_set writefds;
+    ___poll_fdset readfds;
+    ___poll_fdset writefds;
 #endif
 
 #endif

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -102,8 +102,8 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_ELT(fd) ((fd) / ___FDBITS)
 #define ___FD_MASK(fd) ((___fdbits) 1 << ((fd) % ___FDBITS))
 
-#define ___FD_ZERO(set)                       \
-  memset ((set), 0, sizeof (___poll_fd_set))
+#define ___FD_ZERO(set, sz)                        \
+  memset ((set), 0, sz / ___FDBITS)
 #define ___FD_SET(fd, set)                    \
   ((set)->fds[___FD_ELT (fd)] |= ___FD_MASK (fd))
 #define ___FD_CLR(fd, set)                    \
@@ -111,9 +111,7 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_ISSET(fd, set)                  \
   ((set)->fds[___FD_ELT (fd)] & ___FD_MASK (fd))
 
-typedef struct ___poll_fd_set {
-  ___fdbits fds[MAX_POLLFDS / ___FDBITS];
-} ___poll_fd_set;
+typedef ___fdbits *___poll_fd_set;
 
 #endif
 
@@ -147,6 +145,7 @@ typedef struct ___device_select_state_struct
     struct pollfd pollfds[MAX_POLLFDS];
     int pollfd_count;
     /* active set bitmaps */
+    int fdset_size;
     ___poll_fd_set readfds;
     ___poll_fd_set writefds;
 #endif

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -166,10 +166,6 @@ typedef struct ___device_select_state_struct
 #endif
   } ___device_select_state;
 
-#ifndef ___SINGLE_THREADED_VMS
-extern void ___setup_io_thread_local_state ___PVOID;
-#endif
-
 extern void ___device_select_add_relative_timeout
    ___P((___device_select_state *state,
          int i,
@@ -622,7 +618,8 @@ extern ___SCMOBJ ___device_stream_setup
         ());
 
 extern ___SCMOBJ ___device_select
-   ___P((___device **devs,
+   ___P((___processor_state ___ps,
+         ___device **devs,
          int nb_read_devs,
          int nb_write_devs,
          ___time timeout),

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -29,7 +29,7 @@ typedef struct ___device_group_struct
 #define ___TTY_DEVICE_KIND        (___DEVICE_KIND+64)
 #define ___SERIAL_DEVICE_KIND     (___DEVICE_KIND+128)
 #define ___TCP_CLIENT_DEVICE_KIND (___DEVICE_KIND+256)
-#define ___RAW_KIND               (___DEVICE_KIND+512)
+#define ___RAW_DEVICE_KIND        (___DEVICE_KIND+512)
 #define ___TCP_SERVER_DEVICE_KIND (___OBJECT_KIND+512)
 #define ___DIRECTORY_KIND         (___OBJECT_KIND+1024)
 #define ___EVENT_QUEUE_KIND       (___OBJECT_KIND+2048)

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -162,12 +162,13 @@ typedef struct ___device_select_state_struct
 #endif
   } ___device_select_state;
 
-#ifdef USE_poll
-extern int ___fdset_resize_pstate
+extern void ___fdset_resize_pstate
    ___P((___processor_state ___ps,
          int fd),
         ());
-#endif
+
+extern void ___fdset_resize_heap_overflow_clear ___PVOID;
+extern int ___fdset_resize_heap_overflow ___PVOID;
 
 /* 0 if success, 1 if allocation failed in some processor */
 extern ___BOOL ___fdset_resize

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -29,6 +29,7 @@ typedef struct ___device_group_struct
 #define ___TTY_DEVICE_KIND        (___DEVICE_KIND+64)
 #define ___SERIAL_DEVICE_KIND     (___DEVICE_KIND+128)
 #define ___TCP_CLIENT_DEVICE_KIND (___DEVICE_KIND+256)
+#define ___RAW_KIND               (___DEVICE_KIND+512)
 #define ___TCP_SERVER_DEVICE_KIND (___OBJECT_KIND+512)
 #define ___DIRECTORY_KIND         (___OBJECT_KIND+1024)
 #define ___EVENT_QUEUE_KIND       (___OBJECT_KIND+2048)
@@ -814,6 +815,14 @@ extern ___SCMOBJ ___os_device_event_queue_open
 extern ___SCMOBJ ___os_device_event_queue_read
    ___P((___SCMOBJ dev_condvar),
         ());
+
+/* Opening a raw device (file descriptor) */
+
+extern ___SCMOBJ ___os_device_raw_open
+   ___P((___SCMOBJ index,
+         ___SCMOBJ flags),
+        ());
+
 
 /*   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   */
 

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -166,6 +166,9 @@ typedef struct ___device_select_state_struct
 #endif
   } ___device_select_state;
 
+#ifndef ___SINGLE_THREADED_VMS
+extern void ___setup_io_thread_local_state ___PVOID;
+#endif
 
 extern void ___device_select_add_relative_timeout
    ___P((___device_select_state *state,

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -103,7 +103,7 @@ typedef ___SIZE_TS ___fdbits;
 #define ___FD_MASK(fd) ((___fdbits) 1 << ((fd) % ___FDBITS))
 
 #define ___FD_ZERO(set, sz)                        \
-  memset ((set), 0, sz / ___FDBITS)
+  memset ((set), 0, sz/8)
 #define ___FD_SET(fd, set)                    \
   ((set)->fds[___FD_ELT (fd)] |= ___FD_MASK (fd))
 #define ___FD_CLR(fd, set)                    \

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -162,6 +162,19 @@ typedef struct ___device_select_state_struct
 #endif
   } ___device_select_state;
 
+#ifdef USE_poll
+extern int ___fdset_resize_pstate
+   ___P((___processor_state ___ps,
+         int fd),
+        ());
+#endif
+
+/* 0 if success, 1 if allocation failed in some processor */
+extern ___BOOL ___fdset_resize
+   ___P((___processor_state ___ps,
+         int fd),
+        ());
+
 extern void ___device_select_add_relative_timeout
    ___P((___device_select_state *state,
          int i,

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -93,10 +93,6 @@ typedef struct ___device_struct
 #endif
 
 #ifdef USE_poll
-#ifndef MAX_POLLFDS
-#define MAX_POLLFDS MAX_CONDVARS
-#endif
-
 typedef ___SIZE_TS ___fdbits;
 
 #define ___FDBITS (8 * sizeof (___fdbits))
@@ -143,7 +139,7 @@ typedef struct ___device_select_state_struct
 #endif
 
 #ifdef USE_poll
-    struct pollfd pollfds[MAX_POLLFDS];
+    struct pollfd pollfds[MAX_CONDVARS];
     int pollfd_count;
     /* active set bitmaps */
     int fdset_size;

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -30,13 +30,6 @@ ___thread_module ___thread_mod =
 };
 
 
-#ifndef ___SINGLE_THREADED_VMS
-void ___setup_thread_local_state ___PVOID
-{
-  ___setup_io_thread_local_state ();
-}
-#endif
-
 /*---------------------------------------------------------------------------*/
 
 
@@ -48,8 +41,6 @@ ___HIDDEN void *start_pthread_thread
 void *param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
-
-  ___setup_thread_local_state ();
 
   thread->start_fn (thread);
 
@@ -69,8 +60,6 @@ ___HIDDEN DWORD WINAPI start_win32_thread
 LPVOID param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
-
-  ___setup_thread_local_state ();
 
   thread->start_fn (thread);
 

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -35,10 +35,6 @@ ___thread_module ___thread_mod =
 
 #ifdef ___USE_POSIX_THREAD_SYSTEM
 
-#ifdef USE_poll
-extern void ___fdset_state_init ();
-#endif 
-
 ___HIDDEN void *start_pthread_thread
    ___P((void *param),
         (param)
@@ -47,6 +43,7 @@ void *param;)
   ___thread *thread = ___CAST(___thread*,param);
 
 #ifdef USE_poll
+  extern void ___fdset_state_init ();
   ___fdset_state_init ();
 #endif
   

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -46,7 +46,7 @@ void *param;)
   extern void ___fdset_state_init ();
   ___fdset_state_init ();
 #endif
-  
+
   thread->start_fn (thread);
 
   return 0;

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -30,6 +30,13 @@ ___thread_module ___thread_mod =
 };
 
 
+#ifndef ___SINGLE_THREADED_VMS
+void ___setup_thread_local_state ___PVOID
+{
+  ___setup_io_thread_local_state ();
+}
+#endif
+
 /*---------------------------------------------------------------------------*/
 
 
@@ -42,10 +49,7 @@ void *param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
 
-#ifdef USE_poll
-  extern void ___fdset_state_init ();
-  ___fdset_state_init ();
-#endif
+  ___setup_thread_local_state ();
 
   thread->start_fn (thread);
 
@@ -65,6 +69,8 @@ ___HIDDEN DWORD WINAPI start_win32_thread
 LPVOID param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
+
+  ___setup_thread_local_state ();
 
   thread->start_fn (thread);
 

--- a/lib/os_thread.c
+++ b/lib/os_thread.c
@@ -35,6 +35,9 @@ ___thread_module ___thread_mod =
 
 #ifdef ___USE_POSIX_THREAD_SYSTEM
 
+#ifdef USE_poll
+extern void ___fdset_state_init ();
+#endif 
 
 ___HIDDEN void *start_pthread_thread
    ___P((void *param),
@@ -43,6 +46,10 @@ void *param;)
 {
   ___thread *thread = ___CAST(___thread*,param);
 
+#ifdef USE_poll
+  ___fdset_state_init ();
+#endif
+  
   thread->start_fn (thread);
 
   return 0;

--- a/lib/os_thread.h
+++ b/lib/os_thread.h
@@ -95,6 +95,9 @@ extern ___SCMOBJ ___setup_thread_module ___PVOID;
 
 extern void ___cleanup_thread_module ___PVOID;
 
+#ifndef ___SINGLE_THREADED_VMS
+extern void ___setup_thread_local_state ___PVOID;
+#endif
 
 /*---------------------------------------------------------------------------*/
 

--- a/lib/os_thread.h
+++ b/lib/os_thread.h
@@ -95,10 +95,6 @@ extern ___SCMOBJ ___setup_thread_module ___PVOID;
 
 extern void ___cleanup_thread_module ___PVOID;
 
-#ifndef ___SINGLE_THREADED_VMS
-extern void ___setup_thread_local_state ___PVOID;
-#endif
-
 /*---------------------------------------------------------------------------*/
 
 

--- a/lib/os_tty.c
+++ b/lib/os_tty.c
@@ -8123,6 +8123,11 @@ int close_direction;)
               (fd == STDOUT_FILENO) ||
               (fd == STDERR_FILENO);
 
+  ___processor_state ps = ___PSTATE;
+
+  if (___fdset_resize (ps, fd))
+    return ___FIX(___HEAP_OVERFLOW_ERR);
+  
   d = ___CAST(___device_tty*,
               ___ALLOC_MEM(sizeof (___device_tty)));
 

--- a/lib/os_tty.c
+++ b/lib/os_tty.c
@@ -2332,7 +2332,7 @@ ___device_tty *self;)
           }
 
 #endif
-	  
+
 	  if (byte_avail ==  ___NBELEMS(d->output_byte) - d->output_byte_hi)
 	    break;  /* not enough space for a full multibyte character, first flush what we have */
 

--- a/lib/os_tty.c
+++ b/lib/os_tty.c
@@ -7531,7 +7531,7 @@ ___device_select_state *state;)
     {
 #ifdef USE_POSIX
 
-      if (d->fd < 0 || ___FD_ISSET(d->fd, &state->writefds))
+      if (d->fd < 0 || ___FD_ISSET(d->fd, state->writefds))
         state->devs[i] = NULL;
 
 #endif
@@ -7547,7 +7547,7 @@ ___device_select_state *state;)
     {
 #ifdef USE_POSIX
 
-      if (d->fd < 0 || ___FD_ISSET(d->fd, &state->readfds))
+      if (d->fd < 0 || ___FD_ISSET(d->fd, state->readfds))
         state->devs[i] = NULL;
 
 #endif

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -628,7 +628,7 @@ ___WORD target_processor_count;)
   extern void ___fdset_state_init ();
   ___fdset_state_init ();
 #endif
-  
+
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */
   ___sync_op_struct sop;

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -770,7 +770,7 @@ ___sync_op_struct *sop_ptr;)
       break;
 
     case OP_FDSET_RESIZE:
-      sop_ptr->arg[0] = ___fdset_resize_pstate (___ps, sop_ptr->arg[0]);
+      ___fdset_resize_pstate (___ps, sop_ptr->arg[0]);
       break;
 
     case OP_ACTLOG_START:
@@ -939,6 +939,8 @@ int fd;)
   if (fd < ___ps->os.fdset_state.size)
     return 0;
 
+  ___fdset_resize_heap_overflow_clear ();
+  
   ___PSGET
   ___sync_op_struct sop;
 
@@ -947,7 +949,7 @@ int fd;)
 
   on_all_processors (___PSP &sop);
 
-  return sop.arg[0] != 0;
+  return ___fdset_resize_heap_overflow ();
 
 #else
 

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -624,6 +624,11 @@ ___WORD target_processor_count;)
 
 #ifndef ___SINGLE_THREADED_VMS
 
+#ifdef USE_poll
+  extern void ___fdset_state_init ();
+  ___fdset_state_init ();
+#endif
+  
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */
   ___sync_op_struct sop;

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -624,8 +624,6 @@ ___WORD target_processor_count;)
 
 #ifndef ___SINGLE_THREADED_VMS
 
-  ___setup_thread_local_state ();
-
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */
   ___sync_op_struct sop;

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -624,10 +624,7 @@ ___WORD target_processor_count;)
 
 #ifndef ___SINGLE_THREADED_VMS
 
-#ifdef USE_poll
-  extern void ___fdset_state_init ();
-  ___fdset_state_init ();
-#endif
+  ___setup_thread_local_state ();
 
   ___virtual_machine_state ___vms = ___VMSTATE_FROM_PSTATE(___ps);
   int id = ___PROCESSOR_ID(___ps, ___vms); /* id of this processor */

--- a/lib/setup.c
+++ b/lib/setup.c
@@ -308,6 +308,7 @@ ___virtual_machine_state ___vms;)
 #define OP_SET_PROCESSOR_COUNT OP_MAKE( 0,0)
 #define OP_VM_RESIZE           OP_MAKE( 1,0)
 #define OP_GARBAGE_COLLECT     OP_MAKE( 2,COMBINING_ADD)
+#define OP_FDSET_RESIZE        OP_MAKE(10,0)
 #define OP_ACTLOG_START        OP_MAKE(61,0)
 #define OP_ACTLOG_STOP         OP_MAKE(62,0)
 #define OP_NOOP                OP_MAKE(63,0)
@@ -768,6 +769,10 @@ ___sync_op_struct *sop_ptr;)
       sop_ptr->arg[0] = ___garbage_collect_pstate (___ps, sop_ptr->arg[0]);
       break;
 
+    case OP_FDSET_RESIZE:
+      sop_ptr->arg[0] = ___fdset_resize_pstate (___ps, sop_ptr->arg[0]);
+      break;
+
     case OP_ACTLOG_START:
       ___actlog_start_pstate (___ps);
       break;
@@ -920,6 +925,36 @@ ___SIZE_TS requested_words_still;)
   return sop.arg[0] != 0;
 }
 
+
+___EXP_FUNC(___BOOL, ___fdset_resize)
+   ___P((___processor_state ___ps,
+         int fd),
+        (___ps,
+         fd)
+___processor_state ___ps;
+int fd;)
+{
+#ifdef ___USE_poll
+
+  if (fd < ___ps->os.fdset_state.size)
+    return 0;
+
+  ___PSGET
+  ___sync_op_struct sop;
+
+  sop.op = OP_FDSET_RESIZE;
+  sop.arg[0] = fd;
+
+  on_all_processors (___PSP &sop);
+
+  return sop.arg[0] != 0;
+
+#else
+
+  return 0;
+
+#endif
+}
 
 ___EXP_FUNC(void,___actlog_start)
    ___P((___processor_state ___ps),


### PR DESCRIPTION
Implements raw devices so that we can treat raw file descriptors (epoll fds, udp sockets, etc) as first class devices with their own io condvars.
This adds a `raw-device-port` port type, the primitives `##open-raw-device` and `##make-raw-device-port` and the kernel primitives required to support them through a `___device_raw` device.
The new port type is poll/selectable (for read or write) and closable, but doesn't implement any other port procedures because they are not relevant.
It also gets its own port kind, `___RAW_DEVICE_KIND`

This PR started on top of #269, so it also adds dynamic pollsets:
Implements dynamically sized fdsets for poll, so that we can scale to arbitrary numbers of file descriptors without having to manually increase the compile-time constant MAX_POLLFDS.
This solves the issue of crashing on an ___FD_SET (or worse, silently corrupting) when the file descriptor is higher than MAX_POLLFDS by checking and resizing as needed.

Note that it's not intended to side-step the limit on the number of file descriptors that can be concurently polled (that's specified by MAX_CONDVARS), but to allow us to have arbitrary numbers of open file descriptors without fear of crashing in the next file we open and try to read.