### PR TITLE
OS I/O: Raw Devices

### DIFF
--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -150,6 +150,7 @@
 (##define-macro (macro-tty-kind)         (+ 15 64))
 (##define-macro (macro-serial-kind)      (+ 15 128))
 (##define-macro (macro-tcp-client-kind)  (+ 15 256))
+(##define-macro (macro-raw-device-kind)  (+ 15 512))
 (##define-macro (macro-tcp-server-kind)  (+ 1 512))
 (##define-macro (macro-directory-kind)   (+ 1 1024))
 (##define-macro (macro-event-queue-kind) (+ 1 2048))
@@ -528,6 +529,17 @@
 
 (##define-macro (macro-tcp-client-port? obj)
   `(##port-of-kind? ,obj (macro-tcp-client-kind)))
+
+;;; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+;;; Representation of raw device ports.
+
+(define-check-type raw-device-port 'raw-device-port
+  macro-raw-device-port?)
+
+(##define-macro (macro-raw-device-port? obj)
+  `(##port-of-kind? ,obj (macro-raw-device-kind)))
+
 
 ;;; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -545,7 +545,7 @@
   unprintable:
 
   extender: define-type-of-raw-device-port
-  
+
   rdevice-condvar
   wdevice-condvar
   fd

--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -534,6 +534,23 @@
 
 ;;; Representation of raw device ports.
 
+(define-type-of-port raw-device-port
+  id: f55e3678-0414-63d0-3fda-68b9bc518bca
+  type-exhibitor: macro-type-raw-device-port
+  constructor: macro-make-raw-device-port
+  implementer: implement-type-raw-device-port
+  macros:
+  prefix: macro-
+  opaque:
+  unprintable:
+
+  extender: define-type-of-raw-device-port
+  
+  rdevice-condvar
+  wdevice-condvar
+  fd
+)
+
 (define-check-type raw-device-port 'raw-device-port
   macro-raw-device-port?)
 

--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -591,6 +591,7 @@
   rdevice-condvar
   wdevice-condvar
   device
+  id
 )
 
 (##define-macro (macro-raw-device-port? obj)

--- a/lib/_io#.scm
+++ b/lib/_io#.scm
@@ -166,7 +166,7 @@
 (##define-macro (macro-vector-kind)      (+ 3 16384))
 (##define-macro (macro-string-kind)      (+ 7 32768))
 (##define-macro (macro-u8vector-kind)    (+ 15 65536))
-(##define-macro (macro-raw-device-kind)   (+ 1 262144))
+(##define-macro (macro-raw-device-kind)  (+ 1 262144))
 
 ;;; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -590,11 +590,8 @@
 
   rdevice-condvar
   wdevice-condvar
-  fd
+  device
 )
-
-(define-check-type raw-device-port 'raw-device-port
-  macro-raw-device-port?)
 
 (##define-macro (macro-raw-device-port? obj)
   `(##port-of-kind? ,obj (macro-raw-device-kind)))

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8413,8 +8413,15 @@
       ;; access to the port.
 
       (##declare (not interrupts-enabled))
+      (if (##fx= direction (macro-direction-in))
 
-      (##wait-device port direction))
+        (##wait-for-io!
+         (macro-raw-device-port-rdevice-condvar port)
+         (macro-port-rtimeout port))
+
+        (##wait-for-io!
+         (macro-raw-device-port-wdevice-condvar port)
+         (macro-port-wtimeout port))))
 
     (define (close port prim arg1)
 

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8344,15 +8344,15 @@
 
 ;;;----------------------------------------------------------------------------
 
-(define-prim (##make-raw-device-port raw-device device uname direction)
+(define-prim (##make-raw-device-port raw-device device id direction)
   (let ((mutex
          (macro-make-port-mutex))
         (rkind
-         (if (##eq? direction (macro-direction-out))
+         (if (##fx= direction (macro-direction-out))
            (macro-none-kind)
            (macro-raw-device-kind)))
         (wkind
-         (if (##eq? direction (macro-direction-in))
+         (if (##fx= direction (macro-direction-in))
            (macro-none-kind)
            (macro-raw-device-kind)))
         (roptions
@@ -8368,12 +8368,11 @@
         (wtimeout-thunk
          #f)
         (rdevice-condvar
-         (and (##not (##eq? direction (macro-direction-out)))
+         (and (##not (##fx= direction (macro-direction-out)))
               (##make-rdevice-condvar raw-device)))
         (wdevice-condvar
-         (and (##not (##eq? direction (macro-direction-in)))
-              (##make-wdevice-condvar raw-device)))
-        (uname (or uname 'raw-device)))
+         (and (##not (##fx= direction (macro-direction-in)))
+              (##make-wdevice-condvar raw-device))))
 
     (define (name port)
 
@@ -8381,7 +8380,7 @@
       ;; access to the port.
 
       (##declare (not interrupts-enabled))
-      (##list uname (macro-raw-device-port-device port)))
+      (##list (macro-raw-device-id port) (macro-raw-device-port-device port)))
 
     (define (wait port direction)
 
@@ -8472,7 +8471,8 @@
             #f ;; io-exception-handler
             rdevice-condvar
             wdevice-condvar
-            device)))
+            device
+            id)))
       (if rdevice-condvar
         (##io-condvar-port-set! rdevice-condvar port))
       (if wdevice-condvar

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8380,7 +8380,7 @@
       ;; access to the port.
 
       (##declare (not interrupts-enabled))
-      (##list (macro-raw-device-id port) (macro-raw-device-port-device port)))
+      (##list (macro-raw-device-port-id port) (macro-raw-device-port-device port)))
 
     (define (wait port direction)
 

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8344,28 +8344,6 @@
 
 ;;;----------------------------------------------------------------------------
 
-(define-prim (##open-raw-device
-              direction
-              name
-              device)
-
-  (define (fail)
-    (##fail-check-settings 1 ##open-raw-device direction name device))
-
-  (##make-psettings
-   direction
-   '()
-   '()
-   fail
-   (lambda (psettings)
-     (let ((raw-device
-            (##os-device-open-raw
-             device
-             (##psettings->device-flags psettings))))
-       (if (##fixnum? device)
-         (##raise-os-exception #f device ##open-raw-device direction name device)
-         (##make-raw-device-port raw-device device name direction))))))
-
 (define-prim (##make-raw-device-port raw-device device uname direction)
   (let ((mutex
          (macro-make-port-mutex))

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8254,6 +8254,33 @@
         (macro-dynamic-bind output-port port thunk)))))
 
 ;;;----------------------------------------------------------------------------
+(define-prim (##open-raw-device
+              direction
+              name
+              fd
+              settings)
+  (define (fail)
+    (##fail-check-settings 4 ##open-raw-device direction name fd settings))
+  
+  (##make-psettings
+   direction
+   '(direction:)
+   settings
+   fail
+   (lambda (psettings)
+     (let ((device
+            (##os-device-open-raw
+             fd
+             (##psettings->device-flags psettings))))
+       (if (##fixnum? device)
+         (##exit-with-err-code device)
+         (and device
+              (##make-device-port-from-single-device
+               name
+               device
+               psettings)))))))
+
+;;;----------------------------------------------------------------------------
 
 (define-prim (##open-predefined
               direction

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8257,15 +8257,14 @@
 (define-prim (##open-raw-device
               direction
               name
-              fd
-              settings)
+              fd)
   (define (fail)
-    (##fail-check-settings 4 ##open-raw-device direction name fd settings))
-  
+    (##fail-check-settings 1 ##open-raw-device direction name fd))
+
   (##make-psettings
    direction
-   '(direction:)
-   settings
+   '()
+   '()
    fail
    (lambda (psettings)
      (let ((device
@@ -8274,11 +8273,111 @@
              (##psettings->device-flags psettings))))
        (if (##fixnum? device)
          (##exit-with-err-code device)
-         (and device
-              (##make-device-port-from-single-device
-               name
-               device
-               psettings)))))))
+         (##make-raw-device-port device fd name direction))))))
+
+(define-prim (##make-raw-device-port device fd uname direction)
+  (let ((mutex
+         (macro-make-port-mutex))
+        (rkind
+         (if (or (##eq? direction (macro-direction-in))
+                 (##eq? direction (macro-direction-inout)))
+           (macro-raw-device-kind)
+           (macro-none-kind)))
+        (wkind
+         (if (or (##eq? direction (macro-direction-out))
+                 (##eq? direction (macro-direction-inout)))
+           (macro-raw-device-kind)
+           (macro-none-kind)))
+        (roptions
+         0)
+        (rtimeout
+         #t)
+        (rtimeout-thunk
+         #f)
+        (woptions
+         0)
+        (wtimeout
+         #t)
+        (wtimeout-thunk
+         #f)
+        (rdevice-condvar
+         (and (or (##eq? direction (macro-direction-in))
+                  (##eq? direction (macro-direction-inout)))
+              (##make-rdevice-condvar device)))
+        (wdevice-condvar
+         (and (or (##eq? direction (macro-direction-out))
+                  (##eq? direction (macro-direction-inout)))
+              (##make-wdevice-condvar device)))
+        (uname (or uname 'raw-device)))
+
+    (define (name port)
+
+      ;; It is assumed that the thread **does not** have exclusive
+      ;; access to the port.
+
+      (##declare (not interrupts-enabled))
+      (##list uname (macro-raw-device-port-fd port)))
+
+    (define read-datum #f)
+
+    (define write-datum #f)
+
+    (define newline #f)
+
+    (define force-output #f)
+
+    (define set-rtimeout #f)
+
+    (define set-wtimeout #f)
+
+    (define (close port prim arg1)
+
+      ;; It is assumed that the thread **does not** have exclusive
+      ;; access to the port.
+
+      (##declare (not interrupts-enabled))
+
+      (macro-port-mutex-lock! port) ;; get exclusive access to port
+
+      (let ((result
+             (##close-device
+              port
+              (macro-raw-device-port-rdevice-condvar port)
+              (macro-raw-device-port-wdevice-condvar port)
+              prim)))
+        (macro-port-mutex-unlock! port)
+        (if (##fixnum? result)
+            (##raise-os-io-exception port #f result prim arg1)
+            result)))
+
+    (let ((port
+           (macro-make-raw-device-port
+            mutex
+            rkind
+            wkind
+            name
+            read-datum
+            write-datum
+            newline
+            force-output
+            close
+            roptions
+            rtimeout
+            rtimeout-thunk
+            set-rtimeout
+            woptions
+            wtimeout
+            wtimeout-thunk
+            set-wtimeout
+            #f ;; io-exception-handler
+            rdevice-condvar
+            wdevice-condvar
+            fd)))
+      (if rdevice-condvar
+        (##io-condvar-port-set! rdevice-condvar port))
+      (if wdevice-condvar
+        (##io-condvar-port-set! wdevice-condvar port))
+      port)))
 
 ;;;----------------------------------------------------------------------------
 

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -8343,12 +8343,14 @@
         (macro-dynamic-bind output-port port thunk)))))
 
 ;;;----------------------------------------------------------------------------
+
 (define-prim (##open-raw-device
               direction
               name
-              fd)
+              device)
+
   (define (fail)
-    (##fail-check-settings 1 ##open-raw-device direction name fd))
+    (##fail-check-settings 1 ##open-raw-device direction name device))
 
   (##make-psettings
    direction
@@ -8356,27 +8358,25 @@
    '()
    fail
    (lambda (psettings)
-     (let ((device
+     (let ((raw-device
             (##os-device-open-raw
-             fd
+             device
              (##psettings->device-flags psettings))))
        (if (##fixnum? device)
-         (##exit-with-err-code device)
-         (##make-raw-device-port device fd name direction))))))
+         (##raise-os-exception #f device ##open-raw-device direction name device)
+         (##make-raw-device-port raw-device device name direction))))))
 
-(define-prim (##make-raw-device-port device fd uname direction)
+(define-prim (##make-raw-device-port raw-device device uname direction)
   (let ((mutex
          (macro-make-port-mutex))
         (rkind
-         (if (or (##eq? direction (macro-direction-in))
-                 (##eq? direction (macro-direction-inout)))
-           (macro-raw-device-kind)
-           (macro-none-kind)))
+         (if (##eq? direction (macro-direction-out))
+           (macro-none-kind)
+           (macro-raw-device-kind)))
         (wkind
-         (if (or (##eq? direction (macro-direction-out))
-                 (##eq? direction (macro-direction-inout)))
-           (macro-raw-device-kind)
-           (macro-none-kind)))
+         (if (##eq? direction (macro-direction-in))
+           (macro-none-kind)
+           (macro-raw-device-kind)))
         (roptions
          0)
         (rtimeout
@@ -8390,13 +8390,11 @@
         (wtimeout-thunk
          #f)
         (rdevice-condvar
-         (and (or (##eq? direction (macro-direction-in))
-                  (##eq? direction (macro-direction-inout)))
-              (##make-rdevice-condvar device)))
+         (and (##not (##eq? direction (macro-direction-out)))
+              (##make-rdevice-condvar raw-device)))
         (wdevice-condvar
-         (and (or (##eq? direction (macro-direction-out))
-                  (##eq? direction (macro-direction-inout)))
-              (##make-wdevice-condvar device)))
+         (and (##not (##eq? direction (macro-direction-in)))
+              (##make-wdevice-condvar raw-device)))
         (uname (or uname 'raw-device)))
 
     (define (name port)
@@ -8405,7 +8403,7 @@
       ;; access to the port.
 
       (##declare (not interrupts-enabled))
-      (##list uname (macro-raw-device-port-fd port)))
+      (##list uname (macro-raw-device-port-device port)))
 
     (define (wait port direction)
 
@@ -8496,7 +8494,7 @@
             #f ;; io-exception-handler
             rdevice-condvar
             wdevice-condvar
-            fd)))
+            device)))
       (if rdevice-condvar
         (##io-condvar-port-set! rdevice-condvar port))
       (if wdevice-condvar

--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -4281,8 +4281,8 @@ end-of-code
 
 (define-prim ##os-device-open-raw
   (c-lambda (scheme-object  ;; fd
-        scheme-object) ;; flags
-       scheme-object   ;; device
+             scheme-object) ;; flags
+            scheme-object   ;; device
    "___os_device_raw_open"))
 
 (define-prim ##os-device-process-pid

--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -4279,12 +4279,6 @@ end-of-code
             scheme-object   ;; device
    "___os_device_stream_open_process"))
 
-(define-prim ##os-device-open-raw
-  (c-lambda (scheme-object  ;; fd
-             scheme-object) ;; flags
-            scheme-object   ;; device
-   "___os_device_raw_open"))
-
 (define-prim ##os-device-process-pid
   (c-lambda (scheme-object) ;; dev
             scheme-object   ;; pid (fixnum)

--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -4279,6 +4279,12 @@ end-of-code
             scheme-object   ;; device
    "___os_device_stream_open_process"))
 
+(define-prim ##os-device-open-raw-from-fd
+  (c-lambda (scheme-object  ;; fd
+             scheme-object) ;; flags
+            scheme-object   ;; device
+   "___os_device_raw_open_from_fd"))
+
 (define-prim ##os-device-process-pid
   (c-lambda (scheme-object) ;; dev
             scheme-object   ;; pid (fixnum)

--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -4279,6 +4279,12 @@ end-of-code
             scheme-object   ;; device
    "___os_device_stream_open_process"))
 
+(define-prim ##os-device-open-raw
+  (c-lambda (scheme-object  ;; fd
+        scheme-object) ;; flags
+       scheme-object   ;; device
+   "___os_device_raw_open"))
+
 (define-prim ##os-device-process-pid
   (c-lambda (scheme-object) ;; dev
             scheme-object   ;; pid (fixnum)

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8905,9 +8905,15 @@ ___SCMOBJ options;)
 typedef struct ___device_raw_struct
   {
     ___device base;
+
 #ifdef USE_POSIX
     int fd;
 #endif
+
+#ifdef USE_WIN32
+    HANDLE h;
+#endif
+
   } ___device_raw;
 
 typedef struct ___device_raw_vtbl_struct
@@ -8953,6 +8959,12 @@ ___HIDDEN ___SCMOBJ ___device_raw_close_virt
       if (___close_no_EINTR (d->fd) < 0)
         return err_code_from_errno ();
 #endif
+
+#ifdef USE_WIN32
+      if (!CloseHandle (d->h))
+        return err_code_from_GetLastError ();
+#endif
+      
     }
   else if (is_not_closed & direction & ___DIRECTION_RD)
     d->base.read_stage = ___STAGE_CLOSED;
@@ -9041,6 +9053,7 @@ ___HIDDEN ___device_raw_vtbl ___device_raw_table =
 };
 
 #ifdef USE_POSIX
+
 ___SCMOBJ ___device_raw_setup_from_fd
    ___P((___device_raw **dev,
          ___device_group *dgroup,
@@ -9070,22 +9083,14 @@ int direction;)
   d->base.close_direction = 0; /* prevent closing on errors */
 
   if (direction & ___DIRECTION_RD)
-    {
-      d->base.read_stage = ___STAGE_OPEN;
-    }
+    d->base.read_stage = ___STAGE_OPEN;
   else
-    {
-      d->base.read_stage = ___STAGE_CLOSED;
-    }
+    d->base.read_stage = ___STAGE_CLOSED;
 
   if (direction & ___DIRECTION_WR)
-    {
-      d->base.write_stage = ___STAGE_OPEN;
-    }
+    d->base.write_stage = ___STAGE_OPEN;
   else
-    {
-      d->base.write_stage = ___STAGE_CLOSED;
-    }
+    d->base.write_stage = ___STAGE_CLOSED;
 
   d->fd = fd;
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8974,7 +8974,7 @@ ___HIDDEN ___SCMOBJ ___device_raw_close_virt
   return ___FIX(___NO_ERR);
 }
 
-___HIDDEN ___SCMOBJ ___device_raw_select_virt
+___HIDDEN ___SCMOBJ ___device_raw_select_raw_virt
    ___P((___device *self,
          ___BOOL for_writing,
          int i,
@@ -9074,7 +9074,7 @@ ___HIDDEN ___device_raw_vtbl ___device_raw_table =
 {
   {
     ___device_raw_kind,
-    ___device_raw_select_virt,
+    ___device_raw_select_raw_virt,
     ___device_raw_release_virt,
     ___device_raw_force_output_virt,
     ___device_raw_close_virt

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8981,6 +8981,7 @@ ___device_select_state *state;)
 {
   ___device_raw *d = ___CAST(___device_raw*,self);
 
+#ifdef USE_POSIX
   int stage = (for_writing
                ? d->base.write_stage
                : d->base.read_stage);
@@ -9002,6 +9003,9 @@ ___device_select_state *state;)
     state->devs[i] = NULL;
   
   return ___FIX(___NO_ERR);
+#endif
+
+  return ___FIX(___UNIMPL_ERR);
 }
 
 ___HIDDEN ___SCMOBJ ___device_raw_release_virt
@@ -9142,9 +9146,9 @@ ___SCMOBJ flags;)
 
   return result;
 
-#else
-  return ___FIX(___UNIMPL_ERR);
 #endif
+  
+  return ___FIX(___UNIMPL_ERR);
 }
 
 /* Opening a predefined device (stdin, stdout, stderr, console, etc). */

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8982,11 +8982,22 @@ ___device_select_state *state;)
                ? d->base.write_stage
                : d->base.read_stage);
 
-  if (stage == ___STAGE_OPEN)
+  if (pass == ___SELECT_PASS_1)
     {
-      ___device_select_add_fd (state, d->fd, for_writing);
+      if (stage != ___STAGE_OPEN)
+        state->timeout = ___time_mod.time_neg_infinity;
+      else
+        ___device_select_add_fd (state, d->fd, for_writing);
+
+      return ___FIX(___SELECT_SETUP_DONE);
     }
 
+  /* pass == ___SELECT_PASS_CHECK */
+  if (stage != ___STAGE_OPEN)
+    state->devs[i] = NULL;
+  else if (___FD_ISSET(d->fd, state->readfds))
+    state->devs[i] = NULL;
+  
   return ___FIX(___NO_ERR);
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8999,7 +8999,9 @@ ___device_select_state *state;)
   /* pass == ___SELECT_PASS_CHECK */
   if (stage != ___STAGE_OPEN)
     state->devs[i] = NULL;
-  else if (___FD_ISSET(d->fd, &state->readfds))
+  else if (for_writing
+           ? ___FD_ISSET(d->fd, &state->writefds)
+           : ___FD_ISSET(d->fd, &state->readfds))
     state->devs[i] = NULL;
   
   return ___FIX(___NO_ERR);

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8998,7 +8998,7 @@ ___device_select_state *state;)
   /* pass == ___SELECT_PASS_CHECK */
   if (stage != ___STAGE_OPEN)
     state->devs[i] = NULL;
-  else if (___FD_ISSET(d->fd, state->readfds))
+  else if (___FD_ISSET(d->fd, &state->readfds))
     state->devs[i] = NULL;
   
   return ___FIX(___NO_ERR);

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8920,7 +8920,7 @@ ___HIDDEN int ___device_raw_kind
         (self)
 ___device *self;)
 {
-  return ___RAW_KIND;
+  return ___RAW_DEVICE_KIND;
 }
 
 ___HIDDEN ___SCMOBJ ___device_raw_close_virt

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8902,11 +8902,12 @@ ___SCMOBJ options;)
 /*   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   */
 
 /* Raw device file descriptors */
-#ifdef USE_POSIX
 typedef struct ___device_raw_struct
   {
     ___device base;
+#ifdef USE_POSIX
     int fd;
+#endif
   } ___device_raw;
 
 typedef struct ___device_raw_vtbl_struct
@@ -8948,8 +8949,10 @@ ___HIDDEN ___SCMOBJ ___device_raw_close_virt
       d->base.read_stage = ___STAGE_CLOSED; /* avoid multiple closes */
       d->base.write_stage = ___STAGE_CLOSED;
 
+#ifdef USE_POSIX
       if (___close_no_EINTR (d->fd) < 0)
         return err_code_from_errno ();
+#endif
     }
   else if (is_not_closed & direction & ___DIRECTION_RD)
     d->base.read_stage = ___STAGE_CLOSED;
@@ -9031,6 +9034,7 @@ ___HIDDEN ___device_raw_vtbl ___device_raw_table =
   }
 };
 
+#ifdef USE_POSIX
 ___SCMOBJ ___device_raw_setup_from_fd
    ___P((___device_raw **dev,
          ___device_group *dgroup,
@@ -9087,7 +9091,6 @@ int direction;)
 
   return ___FIX(___NO_ERR);
 }
-
 #endif
 
 ___SCMOBJ ___os_device_raw_open

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9158,20 +9158,20 @@ ___SCMOBJ flags;)
   ifd = ___INT(fd);
 
   if ((e = ___device_raw_setup_from_fd
-       (&dev,
-        ___global_device_group (),
-        ifd,
-        direction))
+             (&dev,
+              ___global_device_group (),
+              ifd,
+              direction))
       != ___FIX(___NO_ERR))
     return e;
 
   if ((e = ___NONNULLPOINTER_to_SCMOBJ
-       (___PSTATE,
-        dev,
-        ___FAL,
-        ___device_cleanup_from_ptr,
-        &result,
-        ___RETURN_POS))
+             (___PSTATE,
+              dev,
+              ___FAL,
+              ___device_cleanup_from_ptr,
+              &result,
+              ___RETURN_POS))
       != ___FIX(___NO_ERR))
     {
       ___device_cleanup (___CAST(___device*,dev)); /* ignore error */

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9105,9 +9105,9 @@ int direction;)
 #endif
 
 ___SCMOBJ ___os_device_raw_open_from_fd
-   ___P((___SCMOBJ index,
+   ___P((___SCMOBJ fd,
          ___SCMOBJ flags),
-        (index,
+        (fd,
          flags)
 ___SCMOBJ fd;
 ___SCMOBJ flags;)
@@ -9118,7 +9118,7 @@ ___SCMOBJ flags;)
   ___device_raw *dev;
   ___SCMOBJ result;
 
-  int fd;
+  int ifd;
   int fl;
   int direction;
 
@@ -9126,12 +9126,12 @@ ___SCMOBJ flags;)
                           &fl,
                           &direction);
 
-  fd = ___INT(index);
+  ifd = ___INT(fd);
 
   if ((e = ___device_raw_setup_from_fd
        (&dev,
         ___global_device_group (),
-        fd,
+        ifd,
         direction))
       != ___FIX(___NO_ERR))
     return e;

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8984,14 +8984,7 @@ ___device_select_state *state;)
 
   if (stage == ___STAGE_OPEN)
     {
-      if (for_writing)
-        {
-          ___device_select_add_fd (state, d->fd, 0);
-        }
-      else
-        {
-          ___device_select_add_fd (state, d->fd, 0);
-        }
+      ___device_select_add_fd (state, d->fd, for_writing);
     }
 
   return ___FIX(___NO_ERR);

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9104,7 +9104,7 @@ int direction;)
 }
 #endif
 
-___SCMOBJ ___os_device_raw_open
+___SCMOBJ ___os_device_raw_open_from_fd
    ___P((___SCMOBJ index,
          ___SCMOBJ flags),
         (index,

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8933,7 +8933,7 @@ ___HIDDEN ___SCMOBJ ___device_raw_close_virt
 {
   ___device_raw *d = ___CAST(___device_raw*,self);
   int is_not_closed = 0;
-  
+
   if (d->base.read_stage != ___STAGE_CLOSED)
     is_not_closed |= ___DIRECTION_RD;
 
@@ -8947,7 +8947,7 @@ ___HIDDEN ___SCMOBJ ___device_raw_close_virt
     {
       d->base.read_stage = ___STAGE_CLOSED; /* avoid multiple closes */
       d->base.write_stage = ___STAGE_CLOSED;
-      
+
       if (___close_no_EINTR (d->fd) < 0)
         return err_code_from_errno ();
     }
@@ -9042,7 +9042,7 @@ int fd;
 int direction;)
 {
   ___device_raw *d;
-  
+
   d = ___CAST(___device_raw*,
               ___ALLOC_MEM(sizeof (___device_raw)));
 
@@ -9054,7 +9054,7 @@ int direction;)
   d->base.refcount = 1;
   d->base.direction = direction;
   d->base.close_direction = 0; /* prevent closing on errors */
-  
+
   if (direction & ___DIRECTION_RD)
     {
       d->base.read_stage = ___STAGE_OPEN;
@@ -9072,15 +9072,15 @@ int direction;)
     {
       d->base.write_stage = ___STAGE_CLOSED;
     }
-  
+
   d->fd = fd;
 
   device_transfer_close_responsibility (___CAST(___device*,d));
 
   *dev = d;
-  
+
   ___device_add_to_group (dgroup, &d->base);
-  
+
   return ___FIX(___NO_ERR);
 }
 
@@ -9103,7 +9103,7 @@ ___SCMOBJ flags;)
   int fd;
   int fl;
   int direction;
-  
+
   device_translate_flags (___INT(flags),
                           &fl,
                           &direction);

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8901,6 +8901,241 @@ ___SCMOBJ options;)
 
 /*   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   */
 
+/* Raw device file descriptors */
+#ifdef USE_POSIX
+typedef struct ___device_raw_struct
+  {
+    ___device base;
+    int fd;
+  } ___device_raw;
+
+typedef struct ___device_raw_vtbl_struct
+  {
+    ___device_vtbl base;
+  } ___device_raw_vtbl;
+
+
+___HIDDEN int ___device_raw_kind
+   ___P((___device *self),
+        (self)
+___device *self;)
+{
+  return ___RAW_KIND;
+}
+
+___HIDDEN ___SCMOBJ ___device_raw_close_virt
+   ___P((___device *self,
+         int direction),
+        (self,
+         direction)
+        ___device *self;
+        int direction;)
+{
+  ___device_raw *d = ___CAST(___device_raw*,self);
+  int is_not_closed = 0;
+  
+  if (d->base.read_stage != ___STAGE_CLOSED)
+    is_not_closed |= ___DIRECTION_RD;
+
+  if (d->base.write_stage != ___STAGE_CLOSED)
+    is_not_closed |= ___DIRECTION_WR;
+
+  if (is_not_closed == 0)
+    return ___FIX(___NO_ERR);
+
+  if ((is_not_closed & ~direction) == 0)
+    {
+      d->base.read_stage = ___STAGE_CLOSED; /* avoid multiple closes */
+      d->base.write_stage = ___STAGE_CLOSED;
+      
+      if (___close_no_EINTR (d->fd) < 0)
+        return err_code_from_errno ();
+    }
+  else if (is_not_closed & direction & ___DIRECTION_RD)
+    d->base.read_stage = ___STAGE_CLOSED;
+  else if (is_not_closed & direction & ___DIRECTION_WR)
+    d->base.write_stage = ___STAGE_CLOSED;
+
+  return ___FIX(___NO_ERR);
+}
+
+___HIDDEN ___SCMOBJ ___device_raw_select_virt
+   ___P((___device *self,
+         ___BOOL for_writing,
+         int i,
+         int pass,
+         ___device_select_state *state),
+        (self,
+         for_writing,
+         i,
+         pass,
+         state)
+___device *self;
+___BOOL for_writing;
+int i;
+int pass;
+___device_select_state *state;)
+{
+  ___device_raw *d = ___CAST(___device_raw*,self);
+
+  int stage = (for_writing
+               ? d->base.write_stage
+               : d->base.read_stage);
+
+  if (stage == ___STAGE_OPEN)
+    {
+      if (for_writing)
+        {
+          ___device_select_add_fd (state, d->fd, 0);
+        }
+      else
+        {
+          ___device_select_add_fd (state, d->fd, 0);
+        }
+    }
+
+  return ___FIX(___NO_ERR);
+}
+
+___HIDDEN ___SCMOBJ ___device_raw_release_virt
+   ___P((___device *self),
+        (self)
+___device *self;)
+{
+  return ___FIX(___NO_ERR);
+}
+
+___HIDDEN ___SCMOBJ ___device_raw_force_output_virt
+   ___P((___device *self,
+         int level),
+        (self,
+         level)
+___device *self;
+int level;)
+{
+  return ___FIX(___NO_ERR);
+}
+
+___HIDDEN ___device_raw_vtbl ___device_raw_table =
+{
+  {
+    ___device_raw_kind,
+    ___device_raw_select_virt,
+    ___device_raw_release_virt,
+    ___device_raw_force_output_virt,
+    ___device_raw_close_virt
+  }
+};
+
+___SCMOBJ ___device_raw_setup_from_fd
+   ___P((___device_raw **dev,
+         ___device_group *dgroup,
+         int fd,
+         int direction),
+        (dev,
+         dgroup,
+         fd,
+         direction)
+___device_raw **dev;
+___device_group *dgroup;
+int fd;
+int direction;)
+{
+  ___device_raw *d;
+  
+  d = ___CAST(___device_raw*,
+              ___ALLOC_MEM(sizeof (___device_raw)));
+
+  if (d == NULL)
+    return ___FIX(___HEAP_OVERFLOW_ERR);
+
+
+  d->base.vtbl = &___device_raw_table;
+  d->base.refcount = 1;
+  d->base.direction = direction;
+  d->base.close_direction = 0; /* prevent closing on errors */
+  
+  if (direction & ___DIRECTION_RD)
+    {
+      d->base.read_stage = ___STAGE_OPEN;
+    }
+  else
+    {
+      d->base.read_stage = ___STAGE_CLOSED;
+    }
+
+  if (direction & ___DIRECTION_WR)
+    {
+      d->base.write_stage = ___STAGE_OPEN;
+    }
+  else
+    {
+      d->base.write_stage = ___STAGE_CLOSED;
+    }
+  
+  d->fd = fd;
+  
+  *dev = d;
+
+  return ___FIX(___NO_ERR);
+}
+
+#endif
+
+___SCMOBJ ___os_device_raw_open
+   ___P((___SCMOBJ index,
+         ___SCMOBJ flags),
+        (index,
+         flags)
+___SCMOBJ fd;
+___SCMOBJ flags;)
+{
+
+#ifdef USE_POSIX
+  ___SCMOBJ e;
+  ___device_raw *dev;
+  ___SCMOBJ result;
+
+  int fd;
+  int fl;
+  int direction;
+  
+  device_translate_flags (___INT(flags),
+                          &fl,
+                          &direction);
+
+  fd = ___INT(index);
+
+  if ((e = ___device_raw_setup_from_fd
+       (&dev,
+        ___global_device_group (),
+        fd,
+        direction))
+      != ___FIX(___NO_ERR))
+    return e;
+
+  if ((e = ___NONNULLPOINTER_to_SCMOBJ
+       (___PSTATE,
+        dev,
+        ___FAL,
+        ___device_cleanup_from_ptr,
+        &result,
+        ___RETURN_POS))
+      != ___FIX(___NO_ERR))
+    {
+      ___device_cleanup (___CAST(___device*,dev)); /* ignore error */
+      return e;
+    }
+
+  ___release_scmobj (result);
+
+  return result;
+
+#else
+  return ___FIX(___UNIMPL_ERR);
+#endif
+}
+
 /* Opening a predefined device (stdin, stdout, stderr, console, etc). */
 
 ___SCMOBJ ___os_device_stream_open_predefined

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -9074,9 +9074,13 @@ int direction;)
     }
   
   d->fd = fd;
-  
-  *dev = d;
 
+  device_transfer_close_responsibility (___CAST(___device*,d));
+
+  *dev = d;
+  
+  ___device_add_to_group (dgroup, &d->base);
+  
   return ___FIX(___NO_ERR);
 }
 

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8991,7 +8991,7 @@ int i;
 int pass;
 ___device_select_state *state;)
 {
-  ___device_file *d = ___CAST(___device_file*,self);
+  ___device_raw *d = ___CAST(___device_raw*,self);
   int stage = (for_writing
                ? d->base.write_stage
                : d->base.read_stage);

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -29,6 +29,7 @@ typedef struct ___device_group_struct
 #define ___TTY_DEVICE_KIND        (___DEVICE_KIND+64)
 #define ___SERIAL_DEVICE_KIND     (___DEVICE_KIND+128)
 #define ___TCP_CLIENT_DEVICE_KIND (___DEVICE_KIND+256)
+#define ___RAW_KIND               (___DEVICE_KIND+512)
 #define ___TCP_SERVER_DEVICE_KIND (___OBJECT_KIND+512)
 #define ___DIRECTORY_KIND         (___OBJECT_KIND+1024)
 #define ___EVENT_QUEUE_KIND       (___OBJECT_KIND+2048)
@@ -815,6 +816,14 @@ extern ___SCMOBJ ___os_device_event_queue_open
 extern ___SCMOBJ ___os_device_event_queue_read
    ___P((___SCMOBJ dev_condvar),
         ());
+
+/* Opening a raw device (file descriptor) */
+
+extern ___SCMOBJ ___os_device_raw_open
+   ___P((___SCMOBJ index,
+         ___SCMOBJ flags),
+        ());
+
 
 /*   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   */
 

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -29,7 +29,7 @@ typedef struct ___device_group_struct
 #define ___TTY_DEVICE_KIND        (___DEVICE_KIND+64)
 #define ___SERIAL_DEVICE_KIND     (___DEVICE_KIND+128)
 #define ___TCP_CLIENT_DEVICE_KIND (___DEVICE_KIND+256)
-#define ___RAW_KIND               (___DEVICE_KIND+512)
+#define ___RAW_DEVICE_KIND        (___DEVICE_KIND+512)
 #define ___TCP_SERVER_DEVICE_KIND (___OBJECT_KIND+512)
 #define ___DIRECTORY_KIND         (___OBJECT_KIND+1024)
 #define ___EVENT_QUEUE_KIND       (___OBJECT_KIND+2048)

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -821,7 +821,7 @@ extern ___SCMOBJ ___os_device_event_queue_read
 /* Opening a raw device (file descriptor) */
 
 extern ___SCMOBJ ___os_device_raw_open_from_fd
-   ___P((___SCMOBJ index,
+   ___P((___SCMOBJ fd,
          ___SCMOBJ flags),
         ());
 

--- a/lib/os_io.h
+++ b/lib/os_io.h
@@ -820,7 +820,7 @@ extern ___SCMOBJ ___os_device_event_queue_read
 
 /* Opening a raw device (file descriptor) */
 
-extern ___SCMOBJ ___os_device_raw_open
+extern ___SCMOBJ ___os_device_raw_open_from_fd
    ___P((___SCMOBJ index,
          ___SCMOBJ flags),
         ());


### PR DESCRIPTION
Cherry picked from #271.

Adds raw devices, currently implemented for POSIX only, so that special devices can be used to perform userland read/write operations while integrating with the Gambit scheduler.