### PR TITLE
Fix clear_tls_error_queue spin

### DIFF
--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -4482,10 +4482,6 @@ ___SCMOBJ client_ca_path;)
 ___HIDDEN void clear_tls_error_queue
    ___PVOID
 {
-  while (ERR_peek_error() != 0)
-    {
-      /* ERR_print_errors_fp (stderr); */
-    }
   ERR_clear_error();
 }
 


### PR DESCRIPTION
The loop probably intended to use `ERR_get_error`, `ERR_peek_error` doesn't clear the error.

It's dead code that just spins nonetheless, so kill it.

Fixes #281 