### PR TITLE
Add untransformable-when-serializing bit to struct

### DIFF
--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -4787,7 +4787,7 @@ end-of-code
 ;;     (super   unprintable: equality-skip:)
 ;;     (fields  unprintable: equality-skip:)
 ;;   )
-
+;; TODO: Does not change.
 (##define-macro (macro-type-type-constant)
   (let ((type-type
          (##structure

--- a/lib/_system.scm
+++ b/lib/_system.scm
@@ -2374,7 +2374,7 @@
             (make-table test: ##eq?)
             (if (eq? transform (macro-absent-obj))
                 (lambda (x) x)
-                transform)))
+            transform)))
 
   (define (write-u8 x)
     (let ((ptr (vector-ref state 0)))
@@ -2469,6 +2469,30 @@
           (serialize-exact-int-of-length! n len)
           (alloc! n))))
 
+  (define (serialize! obj w-d)
+    ;; Serialize Wrapper
+    (define (ser! obj)
+      (serialize! obj w-d))
+
+    ;; Check if transformable-when-serialize bit set???
+  (define (serialize-structure! struct struct-length struct-ref)
+    (let* ((len (struct-length struct))
+           (struct-type (##structure-type struct))
+           (struct-type-fields (##type-fields struct-type)))
+      (if (fx< len #x0f)
+        (write-u8 (fxior (structure-tag) len))
+        (begin
+          (write-u8 (fxior (structure-tag) #x0f))
+          (serialize-nonneg-fixnum! len)))
+
+        (serialize! (struct-ref struct 0) 0)
+        (let loop ((i 1) (j 1)) ;; more memory less operations
+          (if (fx< i len)
+              (let* ((field-flag (##vector-ref struct-type-fields j))
+                     (w-d (fxand (fxwraplogical-shift-right field-flag 5) 65535)))
+                (serialize! (struct-ref struct i) w-d)
+                (loop (fx+ i 1) (fx+ j 3)))))))
+
   (define (serialize-vector-like! vect vect-tag vect-length vect-ref)
     (let ((len (vect-length vect)))
       (if (fx< len #x0f)
@@ -2482,7 +2506,8 @@
     (let loop ((i start))
       (if (fx< i end)
           (begin
-            (serialize! (vect-ref vect i))
+            (serialize! (vect-ref vect i)
+                        (if (fx> (fxand w-d 255) 1) (fxwrap- w-d 1) w-d))
             (loop (fx+ i 1))))))
 
   (define (serialize-string-like! str tag mask)
@@ -2553,16 +2578,17 @@
                     (begin
                       (write-u8 (fxior tag mask))
                       (serialize-nonneg-fixnum! subproc-id)))
-                (serialize! (##system-version))
+                (ser! (##system-version))
                 (or (share parent-name)
                     (let ((str (symbol->string parent-name)))
                       (serialize-string-like! str 0 #x7f)
                       (alloc! parent-name)))
                 (alloc! subproc))))))
 
-  (define (serialize! obj)
     (let* ((transform (vector-ref state 4))
-           (obj (transform obj)))
+           (obj (if (or (fx= (fxand w-d 255) 1)
+                        (fx= (fxwraplogical-shift-right w-d 8) 1))
+                  (transform obj) obj)))
       (cond ((fixnum? obj)
              (cond ((and (fx>= obj #x00)
                          (fx< obj #x0b))
@@ -2579,8 +2605,8 @@
                  (begin
                    (alloc! obj)
                    (write-u8 (pair-tag))
-                   (serialize! (car obj))
-                   (serialize! (cdr obj)))))
+                   (serialize! (car obj) (if (fx> (fxand w-d #xff) 1) (fxwrap- w-d 1) w-d))
+                   (serialize! (cdr obj) (if (fx> w-d 511) (fxwrap- w-d 256) w-d))))) ;; width > 1
 
             ((symbol? obj)
              (or (share obj)
@@ -2649,11 +2675,10 @@
                  (or (share obj)
                      (begin
                        (alloc! obj)
-                       (serialize-vector-like!
-                        obj
-                        (structure-tag)
-                        (lambda (obj) (##structure-length obj))
-                        (lambda (obj i) (##unchecked-structure-ref obj i #f #f)))))))
+                       (serialize-structure!
+                         obj
+                         (lambda (obj) (##structure-length obj))
+                         (lambda (obj i) (##unchecked-structure-ref obj i #f #f)))))))
 
             ((procedure? obj)
              (if (closure? obj)
@@ -2670,7 +2695,9 @@
                          (let loop ((i 1))
                            (if (fx<= i nb-closed)
                                (begin
-                                 (serialize! (closure-ref obj i))
+                                 (serialize! (closure-ref obj i)
+                                             (if (fx> (fxand w-d #xff) 1)
+                                               (fxwrap- w-d 1) w-d))
                                  (loop (fx+ i 1))))))))
 
                  (serialize-subprocedure! obj (subprocedure-tag) #x0f)))
@@ -2689,16 +2716,16 @@
              (or (share obj)
                  (begin
                    (write-u8 (ratnum-tag))
-                   (serialize! (macro-ratnum-numerator obj))
-                   (serialize! (macro-ratnum-denominator obj))
+                   (ser! (macro-ratnum-numerator obj))
+                   (ser! (macro-ratnum-denominator obj))
                    (alloc! obj))))
 
             ((cpxnum? obj)
              (or (share obj)
                  (begin
                    (write-u8 (cpxnum-tag))
-                   (serialize! (macro-cpxnum-real obj))
-                   (serialize! (macro-cpxnum-imag obj))
+                   (ser! (macro-cpxnum-real obj))
+                   (ser! (macro-cpxnum-imag obj))
                    (alloc! obj))))
 
             ((continuation? obj)
@@ -2718,8 +2745,9 @@
                                    (let ((next (continuation-next cont)))
                                      (if next
                                          (serialize-cont-frame! next)
-                                         (serialize! (macro-end-of-cont-marker))))
-                                   (serialize! (continuation-ref cont i))))
+                                         ;; Should use serialize! instead of ser!?
+                                         (ser! (macro-end-of-cont-marker))))
+                                         (ser! (continuation-ref cont i))))
                            (loop (fx+ i 1)))))))
 
                (or (share obj)
@@ -2727,7 +2755,7 @@
                      (alloc! obj)
                      (write-u8 (continuation-tag))
                      (serialize-cont-frame! obj)
-                     (serialize! (continuation-denv obj))))))
+                     (ser! (continuation-denv obj))))))
 
             ((frame? obj)
              (or (share obj)
@@ -2741,7 +2769,7 @@
                        (if (fx<= i fs)
                            (begin
                              (if (frame-slot-live? obj i)
-                                 (serialize! (frame-ref obj i)))
+                             (ser! (frame-ref obj i)))
                              (loop (fx+ i 1)))))))))
 
             ((box? obj)
@@ -2750,7 +2778,7 @@
                    (alloc! obj)
                    (write-u8 (boxvalues-tag))
                    (serialize-nonneg-fixnum! 1)
-                   (serialize! (unbox obj)))))
+                   (ser! (unbox obj)))))
 
             ((values? obj)
              (or (share obj)
@@ -2762,7 +2790,7 @@
                      (let loop ((i 0))
                        (if (fx< i len)
                            (begin
-                             (serialize! (values-ref obj i))
+                             (ser! (values-ref obj i))
                              (loop (fx+ i 1)))))))))
 
             ((s8vector? obj)
@@ -2849,9 +2877,9 @@
              (or (share obj)
                  (begin
                    (alloc! obj)
-                   (write-u8 (promise-tag))
-                   (serialize! (promise-thunk obj))
-                   (serialize! (promise-result obj)))))
+                   (write-u8 (promise-tag)) ; Promise is atomic
+                   (serialize! (promise-thunk obj) 0)
+                   (serialize! (promise-result obj) 0))))
 
             ((char? obj)
              (let ((n (char->integer obj)))
@@ -2906,12 +2934,12 @@
                                     (if (and (not (eq? key (macro-unused-obj)))
                                              (not (eq? key (macro-deleted-obj))))
                                         (let ((val (vector-ref obj (fx+ i 1))))
-                                          (serialize! key)
-                                          (serialize! val)))
+                                          (ser! key)
+                                          (ser! val)))
                                     (let ()
                                       (##declare (interrupts-enabled))
                                       (loop (fx+ i 2))))
-                                  (serialize! (macro-unused-obj))))))))
+                                  (ser! (macro-unused-obj))))))))
 
                    (else
                     (cannot-serialize obj))))
@@ -2919,7 +2947,7 @@
             (else
              (cannot-serialize obj)))))
 
-  (serialize! obj)
+  (serialize! obj 257)
 
   (get-output-u8vector))
 
@@ -3057,6 +3085,41 @@
                   (err)))
             obj))))
 
+  ;; Maybe remove the fxand
+  (define-macro (macro-type-width-depth field)
+    `(fxand (fxarithmetic-shift-right field 5) 65535))
+
+  ; TODO merge width and depth into w-d
+  (define (deserialize! w-d)
+    ;; Deserialize wrapper
+    (define (des!)
+      (deserialize! w-d))
+
+  (define (deserialize-structure! x make-struct struct-set!)
+    (let ((len (fxand x #x0f)))
+      (if (fx>= len #x0f)
+        (set! len (deserialize-nonneg-fixnum! 0 0)))
+      (let ((obj (make-struct len)))
+        (alloc! obj)
+        (let* ((type (deserialize! 0))
+               (type-fields (##type-fields type)))
+          (struct-set! obj 0 type)
+          (if (##vector? type-fields)
+            (let loop ((i 1) (j 1))
+              (if (fx< i len)
+                (begin
+                  (let* ((field (##vector-ref type-fields j))
+                         (new-w-d (macro-type-width-depth field)))
+                    (struct-set! obj i (deserialize! new-w-d))
+                    (loop (fx+ i 1) (fx+ j 3))))))
+            (begin
+              (let loop ((i 1))
+                (if (fx< i len)
+                  (begin
+                    (struct-set! obj i (deserialize! 0))
+                    (loop (fx+ i 1)))))))
+          obj))))
+
   (define (deserialize-vector-like! x make-vect vect-set!)
     (let* ((len (fxand x #x0f)))
       (if (fx< len #x0f)
@@ -3073,7 +3136,7 @@
       (let loop ((i 0))
         (if (fx< i len)
             (begin
-              (vect-set! obj i (deserialize!))
+              (vect-set! obj i (deserialize! (if (fx> (fxand w-d 255) 1) (fxwrap- w-d 1) w-d)))
               (loop (fx+ i 1)))
             obj))))
 
@@ -3122,7 +3185,7 @@
             (deserialize-subprocedure-with-id! subproc-id)))))
 
   (define (deserialize-subprocedure-with-id! subproc-id)
-    (let ((v (deserialize!)))
+    (let ((v (deserialize! 0)))
       (if (not (eqv? v (##system-version)))
           (err)
           (let* ((x
@@ -3155,14 +3218,18 @@
       (if (fx= x 1)
           (##make-global-var sym))))
 
-  (define (deserialize!)
+  (define (id x) x) ;; Identity
+
     (let ((x (read-u8)))
       (if (fx>= x (shared-tag))
 
           (shared-ref
            (deserialize-nonneg-fixnum! (fxand x #x7f) 7))
-
-          ((vector-ref state 4) ;; transform
+          (let ((transform (if (or (fx= (fxand w-d 255) 1)
+                                   (fx= (fxarithmetic-shift-right w-d 8) 1))
+                             (vector-ref state 4) ;; transform
+                             id)))
+          (transform
            (cond ((fx>= x (false-tag))
                   (cond ((fx= x (false-tag))
                          #f)
@@ -3200,8 +3267,8 @@
                         ((fx= x (promise-tag))
                          (let ((obj (make-promise #f)))
                            (alloc! obj)
-                           (let* ((thunk (deserialize!))
-                                  (result (deserialize!)))
+                           (let* ((thunk (des!))
+                                  (result (des!)))
                              (promise-thunk-set! obj thunk)
                              (promise-result-set! obj result)
                              obj)))
@@ -3230,8 +3297,8 @@
                            obj))
 
                         ((fx= x (ratnum-tag))
-                         (let* ((num (deserialize!))
-                                (den (deserialize!)))
+                         (let* ((num (des!))
+                                (den (des!)))
                            (if #f #;(or (and (fixnum? den)
                                              (fx<= den 1))
                                         (and (bignum? den)
@@ -3243,8 +3310,8 @@
                              obj))))
 
                   ((fx= x (cpxnum-tag))
-                   (let* ((real (deserialize!))
-                          (imag (deserialize!)))
+                   (let* ((real (des!))
+                          (imag (des!)))
                      (if #f #;(or (not (real? real))
                                   (not (real? imag)))
                          (err)
@@ -3255,8 +3322,8 @@
                   ((fx= x (pair-tag))
                    (let ((obj (cons #f #f)))
                      (alloc! obj)
-                     (let* ((a (deserialize!))
-                            (d (deserialize!)))
+                     (let* ((a (deserialize! (if (fx> (fxand w-d #xff) 1) (fxwrap- w-d 1) w-d)))
+                            (d (deserialize! (if (fx> w-d 511) (fxwrap- w-d 256) w-d))))
                        (set-car! obj a)
                        (set-cdr! obj d)
                        obj)))
@@ -3265,8 +3332,8 @@
                    (let ((obj
                           (make-continuation (macro-end-of-cont-marker) #f)))
                      (alloc! obj)
-                     (let* ((frame (deserialize!))
-                            (denv (deserialize!)))
+                     (let* ((frame (des!))
+                            (denv (des!)))
                        (if #f #;(not (frame? frame)) ;; should also check denv
                            (err)
                            (begin
@@ -3279,14 +3346,14 @@
                      (if (fx= len 1)
                          (let ((obj (box #f)))
                            (alloc! obj)
-                           (set-box! obj (deserialize!))
+                           (set-box! obj (des!))
                            obj)
                          (let ((obj (make-values len)))
                            (alloc! obj)
                            (let loop ((i 0))
                              (if (fx< i len)
                                  (begin
-                                   (values-set! obj i (deserialize!))
+                                   (values-set! obj i (des!))
                                    (loop (fx+ i 1)))
                                  obj))))))
 
@@ -3325,7 +3392,7 @@
                                  (alloc! obj)
                                  (let loop ((i 1))
                                    (if (fx<= i nb-closed)
-                                       (let ((x (deserialize!)))
+                                       (let ((x (deserialize! (if (fx> (fxand w-d #xff) 1) (fxwrap- w-d 1) w-d))))
                                          (closure-set! obj i x)
                                          (loop (fx+ i 1)))
                                        obj))))))))
@@ -3344,7 +3411,7 @@
                                     obj
                                     i
                                     (if (frame-slot-live? obj i)
-                                        (deserialize!)
+                                        (des!)
                                         0))
                                    (loop (fx+ i 1)))
                                  obj))))))
@@ -3371,9 +3438,9 @@
                            (macro-gc-hash-table-free-set! obj free)
                            (let loop ((i (macro-gc-hash-table-key0)))
                              (if (fx< i (vector-length obj))
-                                 (let ((key (deserialize!)))
+                                 (let ((key (des!)))
                                    (if (not (eq? key (macro-unused-obj)))
-                                       (let ((val (deserialize!)))
+                                       (let ((val (des!)))
                                          (vector-set! obj i key)
                                          (vector-set! obj (fx+ i 1) val)
                                          (loop (fx+ i 2)))
@@ -3490,7 +3557,7 @@
                (deserialize-subprocedure-with-id! subproc-id)))
 
             ((fx>= x (structure-tag))
-             (deserialize-vector-like!
+             (deserialize-structure!
               x
               (lambda (len)
                 (##make-structure
@@ -3517,9 +3584,9 @@
                     (obj (string->symbol name)))
                (create-global-var-if-needed obj)
                (alloc! obj)
-               obj)))))))
+               obj))))))))
 
-  (let ((obj (deserialize!)))
+  (let ((obj (deserialize! 257)))
     (if (eof?)
         obj
         (err))))

--- a/tests/unit-tests/05-serdes/serdes.scm
+++ b/tests/unit-tests/05-serdes/serdes.scm
@@ -2,7 +2,9 @@
 
 (declare (block)) ;; needed for serialization/deserialization when compiled
 
+(define i 0)
 (define (serdes1 obj)
+  ;(println (object->string obj))
   (let ((ser (object->u8vector obj)))
     (let ((des (u8vector->object ser)))
       des)))
@@ -12,11 +14,47 @@
     (let ((des (u8vector->object ser (lambda (x) x))))
       des)))
 
+(define (serdes3 obj expect-ser expect-des)
+  (define (make-transform expected)
+    (lambda (o)
+      (if (pair? expected)
+        (let ((cur (car expected)))
+          (check-equal? o cur)
+          (set! expected (cdr expected))))
+      o))
+
+  (define (ser lst)
+    (object->u8vector obj (make-transform expect-ser)))
+
+  (define (des u8vect)
+    (u8vector->object u8vect)) ;(make-transform expect-des)))
+
+  (let* ((ser-obj (ser obj))
+         (des-obj (des ser-obj)))
+      des-obj))
+
 (define-type point
   id: the-point-object
   x
   y
   z)
+
+(define-type point-0
+  id: the-point-0object
+  x
+  (y serialization-atomicity-depth: 2
+     serialization-atomicity-width: 2))
+
+(define-type point-1
+  id: the-point-1-object
+  (x serialization-atomicity-depth: 2
+     serialization-atomicity-width: 2)
+  y)
+
+(define-type point-2
+  id: the-point-2-object
+  (x serialization-atomicity-depth: 2)
+  (y serialization-atomicity-depth: 2))
 
 (define objects
   (list (cons 11 22)
@@ -105,6 +143,21 @@
         (make-point 1 2 3)
         ))
 
+(define structs
+  (let* ((p0 (make-point 1 2 3))
+        (p1 (make-point-0 1 2))
+        (p2 (make-point-1 1 2))
+        (p3 (make-point-2 1 2))
+        (o4 (list p1 3 4)))
+    (list
+      (vector p0 (list p0 1 2 3) (list 1 2 3 p0))
+      (vector p1 (list p1 1) (list 1 p1))
+      (vector p2 (list p2 2) (list 2 p2))
+      (vector p3 (list p3) (list p3))
+      (vector o4
+              (list o4 p1 1 '(3 4) 3 '(4) 4 '())
+              (list 1 p1 3 4 '() '(4) '(3 4) o4)))))
+
 (define t (list->table '((a . 11) (b . 22))))
 
 (for-each
@@ -117,6 +170,14 @@
  (lambda (obj)
    (check-equal? (serdes2 obj) obj))
  objects)
+
+(for-each
+  (lambda (test)
+    (let ((o (vector-ref test 0))
+          (expect-ser (vector-ref test 1))
+          (expect-des (vector-ref test 2)))
+      (check-equal? (serdes3 o expect-ser expect-des) o)))
+  structs)
 
 (define circular (cons 11 22))
 
@@ -136,3 +197,62 @@
 (define add10 (make-adder 10))
 
 (check-equal? ((serdes1 add10) 5) 15)
+
+(define-type container-5-5
+  id: container-5-5-unique-id
+  ;; Depth: 3 + cell
+  ;; Width: 4
+  (data serialization-atomicity-depth: 5
+        serialization-atomicity-width: 5))
+
+(define-type container-0-5
+  id: container-0-5-unique-id
+  ;; Depth: 3 + cell
+  (data serialization-atomicity-depth: 5
+        serialization-atomicity-width: 0))
+
+(define-type container-5-0
+  id: container-5-0-unique-id
+  ;; Width: 4
+  (data serialization-atomicity-depth: 0
+        serialization-atomicity-width: 5))
+
+
+(define (create-list-table w d)
+  (let loop ((d d) (acc '()))
+    (if (> d 0)
+      (loop (- d 1)
+            (cons acc
+              (vector->list (make-vector w)))) acc)))
+
+(define lst (create-list-table 30 30))
+
+(define (test-w-d-attribute
+          make-obj
+          obj-data
+          w d lst)
+  (check-equal?
+    (obj-data
+      (u8vector->object
+        (object->u8vector
+          (make-obj lst)
+          (lambda (o)
+            (if (pair? o)
+              '()
+              o)))))
+    (create-list-table w d)))
+
+(test-w-d-attribute
+  make-container-5-5
+  container-5-5-data
+  3 4 lst)
+
+(test-w-d-attribute
+  make-container-5-0
+  container-5-0-data
+  3 30 lst)
+
+(test-w-d-attribute
+  make-container-0-5
+  container-0-5-data
+  30 4 lst)


### PR DESCRIPTION
1. modifications in lib/_nonstd.scm
  - Add transformable-when-serializing and
    untransformable-when-serializing to allowed
    field options.
  - Add untransformable-when-serializing (+32) to
    structure field flags.
2. modifications in lib/_kernel.scm
  - Change type bootstrap's type descriptor
    to use the untransformable-when-serializing bit.
3. modification in lib/_system.scm
  - Add a flags in the state contain in
    object->u8vector and u8vector->object.
  - Add the function 'serialize-structure! in
    object->u8vector.
  - Add the function 'deserialize-structure! in
    u8vector->object.
4. add unit-test to cover the case of untransformable-when-serializing.

TODO
====
- Re-think the structure of object->u8vector and u8vector->object
  so that the flags in the state does not require assignement.
  Should use closure property.

  (define (serialize! obj flag)
    (define (ser! obj)
      (serialize obj flag))

    ...)