### PR TITLE
[WIP] TLS certificate validation

### DIFF
--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -4460,6 +4460,10 @@ ___SCMOBJ client_ca_path;)
       SSL_CTX_set_mode (c->tls_ctx,
                         SSL_MODE_ENABLE_PARTIAL_WRITE |
                         SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+
+      /* always verify server certificate */
+      SSL_CTX_set_default_verify_paths (c->tls_ctx);
+      SSL_CTX_set_verify (c->tls_ctx, SSL_VERIFY_PEER, NULL);
   }
 
   if ((scm_e =___NONNULLPOINTER_to_SCMOBJ


### PR DESCRIPTION
Closes #312 
Closes #200 

Adds clients-side TLS certificate validation.

This the first pass, which adds validation by default, using the default certificate chain. It is sufficient for the general usage of TLS clients.

Nonetheless, there are a couple of special cases we also want to support:
- Allow custom verify paths (necessary for custom certificate authorities and testing)
- Allow an insecure mode where we can disable certificate validation (testing, misconfigured servers)

Also of note: there is no special error reported by certificate validation failure, just a delayed SSL error when we force output in the port. This is far from ideal, we would like to have a nice loud and clear error when certificate validation fails.
