### PR TITLE
thread-group-specific

### DIFF
--- a/lib/_thread#.scm
+++ b/lib/_thread#.scm
@@ -3909,6 +3909,9 @@
   (suspend-condvar
    macro-tgroup-suspend-condvar
    macro-tgroup-suspend-condvar-set!)
+  (specific
+   macro-tgroup-specific
+   macro-tgroup-specific-set!)
   (unused1
    macro-tgroup-unused1
    macro-tgroup-unused1-set!)
@@ -3927,9 +3930,6 @@
   (unused6
    macro-tgroup-unused6
    macro-tgroup-unused6-set!)
-  (unused7
-   macro-tgroup-unused7
-   macro-tgroup-unused7-set!)
   (threads-deq-next ;; must be at same pos as the same name field in a thread
    macro-tgroup-threads-deq-next
    macro-tgroup-threads-deq-next-set!)

--- a/lib/_thread.scm
+++ b/lib/_thread.scm
@@ -4468,6 +4468,18 @@
     (macro-check-tgroup tgroup 1 (thread-group-parent tgroup)
       (macro-tgroup-parent tgroup))))
 
+(define-prim (thread-group-specific tgroup)
+  (macro-force-vars (tgroup)
+    (macro-check-tgroup tgroup 1 (thread-group-specific tgroup)
+      (macro-tgroup-specific tgroup))))
+
+(define-prim (thread-group-specific-set! tgroup obj)
+  (macro-force-vars (tgroup)
+    (macro-check-tgroup tgroup 1 (thread-group-specific-set! tgroup obj)
+      (begin
+        (macro-tgroup-specific-set! tgroup obj)
+        (##void)))))
+
 (define-prim (thread-group-suspend! tgroup)
   (macro-force-vars (tgroup)
     (macro-check-tgroup tgroup 1 (thread-group-suspend! tgroup)
@@ -7845,6 +7857,18 @@
     (macro-check-tgroup tgroup 1 (thread-group-parent tgroup)
       (macro-tgroup-parent tgroup))))
 
+(define-prim (thread-group-specific tgroup)
+  (macro-force-vars (tgroup)
+    (macro-check-tgroup tgroup 1 (thread-group-specific tgroup)
+      (macro-tgroup-specific tgroup))))
+
+(define-prim (thread-group-specific-set! tgroup obj)
+  (macro-force-vars (tgroup)
+    (macro-check-tgroup tgroup 1 (thread-group-specific-set! tgroup obj)
+      (begin
+        (macro-tgroup-specific-set! tgroup obj)
+        (##void)))))
+
 (define-prim (thread-group-suspend! tgroup)
   (macro-force-vars (tgroup)
     (macro-check-tgroup tgroup 1 (thread-group-suspend! tgroup)
@@ -8594,9 +8618,9 @@
    (##declare (not interrupts-enabled))
    (set! ##deferred-user-interrupt? #t)
    (##void))
-     
+
 (define defer-user-interrupts ##defer-user-interrupts)
-     
+
 (define ##current-user-interrupt-handler
   (##make-parameter
    ##defer-user-interrupts

--- a/lib/gambit#.scm
+++ b/lib/gambit#.scm
@@ -779,6 +779,8 @@ thread-group->thread-list
 thread-group->thread-vector
 thread-group-name
 thread-group-parent
+thread-group-specific
+thread-group-specific-set!
 thread-group-resume!
 thread-group-suspend!
 thread-group-terminate!


### PR DESCRIPTION
Adds a specific field to thread-groups, similar to other structures. This allows us to easily associate shared state for all threads in a thread group.

The patch commandeers tgroup-unused1 to act as the specific field and adds `thread-group-specific` and `thread-group-specific-set!` primitives.