### PR TITLE
Minor doc patches

### DIFF
--- a/doc/gambit.txi
+++ b/doc/gambit.txi
@@ -13,6 +13,7 @@
 
 @ifinfo
 @format
+INFO-DIR-SECTION Programming
 START-INFO-DIR-ENTRY
 * Gambit: (gambit).		A portable implementation of Scheme.
 * gsi: (gambit) interpreter.	Gambit interpreter.

--- a/doc/gsi.1
+++ b/doc/gsi.1
@@ -117,12 +117,6 @@ available via the Info system (info gambit), in html via doc-base, or as
 files in /usr/share/doc/gambit (html, pdf, txt).
 
 .br
-
-The Debian package r5rs-doc provides the Revised(5) Report on the Algorithmic
-Language Scheme in several formats.  That document is the defining
-description of the programming language Scheme.
-
-.br
 \fBdhelp(1), gcc(1), update-alternatives(8)\fP
 .SH COPYRIGHT
 .br


### PR DESCRIPTION
These patches come from the [Debian package repository for gambit](https://salsa.debian.org/abdelq-guest/gambc/tree/master/debian/patches).

The manpage makes a reference to the obsolete package [r5rs-doc](https://packages.debian.org/search?keywords=r5rs-doc) that no longer exists since `wheezy (oldoldstable)`.

The texinfo file is also missing an INFO-DIR-SECTION, which has been added.