### PR TITLE
define tgroup-specific field in SMP branch

### DIFF
--- a/lib/_thread#.scm
+++ b/lib/_thread#.scm
@@ -1897,7 +1897,10 @@
    macro-tgroup-tgroups)
   (name
    macro-tgroup-name)
-  unused-field6
+  (specific
+   macro-tgroup-specific
+   macro-tgroup-specific-set!)
+
   unused-field7
 
   (parent ;; thread-group this thread-group belongs to


### PR DESCRIPTION
the thread-group structure is missing the specific field in the SMP branch; mea cupla.