### PR TITLE
Generate single byte opcode for x86_64 int3 instruction

### DIFF
--- a/gsc/_x86.scm
+++ b/gsc/_x86.scm
@@ -975,8 +975,11 @@
 ;;; X86 instruction: INT.
 
 (define (x86-int cgc n)
-  (asm-8 cgc #xcd) ;; opcode
-  (asm-8 cgc n)
+  (if (fx= n 3)
+      (asm-8 cgc #xcc) ;; opcode
+      (begin
+        (asm-8 cgc #xcd) ;; opcode
+        (asm-8 cgc n)))
   (if (codegen-context-listing-format cgc)
       (x86-listing cgc
                    "int"


### PR DESCRIPTION
From Intel manual Vol. 2A:

> The INT 3 instruction generates a special one byte opcode (CC) that is intended for calling the debug exception handler. (This one byte form is valuable because it can be used to replace the first byte of any instruction with a breakpoint, including other one byte instructions, without over-writing other code).
> ...
> These features do not pertain to CD03, the “normal” 2-byte opcode for INT 3. Intel and Microsoft assemblers will not generate the CD03 opcode from any mnemonic, but this opcode can be created by direct numeric code definition or by self-modifying code.

So it should be enough to let the user use the asm-* functions if the 2-byte opcode is needed.