### PR TITLE
Fix wrong x86_64 encoding when r13 is used as base register

### DIFF
--- a/gsc/_x86.scm
+++ b/gsc/_x86.scm
@@ -507,7 +507,7 @@
                                 (asm-32-le cgc offset))
                                ((asm-signed8? offset)
                                 (if (or (not (fx= offset 0)) ;; non-null offset?
-                                        (fx= field1 5))      ;; or RBP
+                                        (fx= field1-lo 5))   ;; or RBP/R13
                                     (begin ;; use 8 bit displacement
                                       (asm-8 cgc (fx+ #x40 modrm*)) ;; ModR/M
                                       (asm-8 cgc sib) ;; SIB


### PR DESCRIPTION
From intel manual volume 2, Table 2-5:
```
Using RBP or R13 without displacement must be done
using mod = 01 with a displacement of 0.
```

So this commit should fix wrong encoding when r13 is used as base register. Ex:

Old wrong encoding:
`mov rax,[r13+rax] -> 49 8b 04 05`     

New encoding:
`mov     rax,[r13+rax] -> 49 8b 44 05 00  `