### PR TITLE
Fix the config script for windows to handle CONF_USE_SIGSET_T

### DIFF
--- a/misc/configure-vstudio.js
+++ b/misc/configure-vstudio.js
@@ -372,7 +372,8 @@ FixupFile(
         "CONF_HAVE_CONDITION_VARIABLE":      CONF_HAVE_CONDITION_VARIABLE,
         "CONF_MAX_PROCESSORS":               CONF_MAX_PROCESSORS,
         "CONF_ACTIVITY_LOG":                 CONF_ACTIVITY_LOG,
-        "CONF_BOOL":                         CONF_BOOL
+        "CONF_BOOL":                         CONF_BOOL,
+        "CONF_USE_SIGSET_T":                 "CONF_USE_SIGSET_T"
     });
 
 FixupFile(


### PR DESCRIPTION
I took the liberty of creating the PR even before discussing. This change will only affect build on windows that use uses the js file so it should be safe.
After applying this change, I can build gsc/gsi using 32bit CL.