### PR TITLE
fix make-tls-context with LibreSSL

### DIFF
--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -4146,12 +4146,12 @@ ___SCMOBJ client_ca_path;)
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_TLSv1)));
         case 0x301:
-#ifndef LIBRESSL_VERSION_NUMBER
+#ifndef OPENSSL_NO_SSL3
           OPENSSL_CHECK_ERROR ((SSL_OP_NO_SSLv3 &
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv3)));
         case 0x300:
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef OPENSSL_NO_SSL2
           OPENSSL_CHECK_ERROR ((SSL_OP_NO_SSLv2 &
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv2)));
@@ -4383,12 +4383,12 @@ ___SCMOBJ client_ca_path;)
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_TLSv1)));
         case 0x301:
-#ifndef LIBRESSL_VERSION_NUMBER
+#ifndef OPENSSL_NO_SSL3
           OPENSSL_CHECK_ERROR ((SSL_OP_NO_SSLv3 &
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv3)));
         case 0x300:
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifndef OPENSSL_NO_SSL2
           OPENSSL_CHECK_ERROR ((SSL_OP_NO_SSLv2 &
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv2)));

--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -4146,6 +4146,7 @@ ___SCMOBJ client_ca_path;)
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_TLSv1)));
         case 0x301:
+#ifndef LIBRESSL_VERSION_NUMBER
           OPENSSL_CHECK_ERROR ((SSL_OP_NO_SSLv3 &
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv3)));
@@ -4155,6 +4156,7 @@ ___SCMOBJ client_ca_path;)
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv2)));
         case 0x200:
+#endif
 #endif
           break;
         default:
@@ -4381,6 +4383,7 @@ ___SCMOBJ client_ca_path;)
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_TLSv1)));
         case 0x301:
+#ifndef LIBRESSL_VERSION_NUMBER
           OPENSSL_CHECK_ERROR ((SSL_OP_NO_SSLv3 &
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv3)));
@@ -4390,6 +4393,7 @@ ___SCMOBJ client_ca_path;)
                                 SSL_CTX_set_options (c->tls_ctx,
                                                      SSL_OP_NO_SSLv2)));
         case 0x200:
+#endif
 #endif
           break;
         default:


### PR DESCRIPTION
LibreSSL no longer supports SSL protocols and so has set old SSL_OP_NO_SSLv3 and
SSL_NO_SSLv2 defines to 0. Make the current TLS configuration setup skip using
them when using LibreSSL. Fixes the #366.