### PR TITLE
Add ___ps argument to mem.c's ___glo_list_search_obj() & ___obj_to_global_var(), making --enable-multiple-vms build again.

### DIFF
--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -3994,7 +3994,7 @@ end-of-code
 
 (define-prim (##object->global-var obj primitive?)
   (##c-code
-   "___RESULT = ___obj_to_global_var (___ARG1, !___FALSEP(___ARG2));"
+   "___RESULT = ___obj_to_global_var (___ps, ___ARG1, !___FALSEP(___ARG2));"
    obj
    primitive?))
 

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -1203,9 +1203,11 @@ ___glo_struct *glo;)
 
 
 ___glo_struct *___glo_list_search_obj
-   ___P((___SCMOBJ obj,
+   ___P((___processor_state ___ps,
+         ___SCMOBJ obj,
          ___BOOL prm),
-        (obj,
+        (___ps,
+         obj,
          prm)
 ___SCMOBJ obj;
 ___BOOL prm;)
@@ -1285,9 +1287,11 @@ ___glo_struct *glo;)
 
 
 ___SCMOBJ ___obj_to_global_var
-   ___P((___SCMOBJ obj,
+   ___P((___processor_state ___ps,
+         ___SCMOBJ obj,
          ___BOOL prm),
-        (obj,
+        (___ps,
+         obj,
          prm)
 ___SCMOBJ obj;
 ___BOOL prm;)
@@ -1298,7 +1302,7 @@ ___BOOL prm;)
    * is checked, otherwise the val field is checked.
    */
 
-  return ___glo_struct_to_global_var (___glo_list_search_obj (obj, prm));
+  return ___glo_struct_to_global_var (___glo_list_search_obj (___ps,obj, prm));
 }
 
 

--- a/lib/mem.h
+++ b/lib/mem.h
@@ -229,7 +229,8 @@ extern ___SCMOBJ ___glo_struct_to_global_var
         ());
 
 extern ___SCMOBJ ___obj_to_global_var
-   ___P((___SCMOBJ obj,
+   ___P((___processor_state ___ps,
+         ___SCMOBJ obj,
          ___BOOL prm),
         ());
 


### PR DESCRIPTION
 * Before merging please validate that this is an existing problem indeed, in the related work I have had friction from the Windows WSL Linux build platform. *

"./configure --enable-multiple-vms ...; make" for Gambit master 2019-06-03 and at least back to 2018-11 has compile failure in mem.c because ___ps is missing in ___glo_list_search_obj, this commit leads ___ps all the way from the call chain's source in _kernel.scm's |##object->global-var| via mem.c's ___obj_to_global_var and then to there.

gcc ... mem.c ...
In file included from mem.c:7:0:
mem.c: In function ‘___glo_list_search_obj’:
../include/gambit.h:4426:62: error: ‘___ps’ undeclared (first use in this function)
 #define ___GLOCELL(x)___GLOCELL_IN_VM(___VMSTATE_FROM_PSTATE(___ps),x)