### PR TITLE
Don't use sysctl and sysctlbyname on Linux

### DIFF
--- a/lib/os.h
+++ b/lib/os.h
@@ -281,11 +281,15 @@
 #endif
 
 #ifdef HAVE_SYSCTL
+#ifndef __linux__
 #define USE_sysctl
+#endif
 #endif
 
 #ifdef HAVE_SYSCTLBYNAME
+#ifndef __linux__
 #define USE_sysctlbyname
+#endif
 #endif
 
 #ifdef HAVE_SYSLOG


### PR DESCRIPTION
Has been deprecated and will probably be removed at some point or another.