### PR TITLE
Clang -fomit-frame-pointer bug

### DIFF
--- a/configure
+++ b/configure
@@ -9791,6 +9791,10 @@ if test "$C_COMP_CLANG" != yes -a "$C_COMP_GNUC_VERSION" -ge 402000 -a "$C_COMP_
   GNU_GCC_MOVE_LOOP_INVARIANTS_POSSIBLE_BUG=yes
 fi
 
+if test "$C_COMP_CLANG" = yes -a "$C_COMP_CLANG_VERSION" -ge 1100000; then
+  OMIT_FRAME_POINTER_POSSIBLE_BUG=yes
+fi
+
 case "$target_os" in
   darwin*) # strangely this bug only appears on Mac OS
     if test "$C_COMP_CLANG" != yes -a "$C_COMP_GNUC_VERSION" -ge 600000 -a "$DASH_fno_ipa_ra" != "" -a "$ENABLE_SHARED" = yes -a "$ENABLE_C_OPT" != no; then
@@ -11824,17 +11828,19 @@ DASH_shared="$ac_cv_DASH_shared"
     FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_freschedule_modulo_scheduled_loops"
   fi
 
-  case "$target_os" in
+  if test "$OMIT_FRAME_POINTER_POSSIBLE_BUG" != yes; then
+    case "$target_os" in
 
-     mingw*) # MinGW's setjmp seems to need the frame pointer
-             ;;
+       mingw*) # MinGW's setjmp seems to need the frame pointer
+               ;;
 
-          *) # other systems are fine as far as I can tell
-             if test "$ENABLE_DEBUG" != yes -a "$ENABLE_PROFILE" != yes; then
-               FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_fomit_frame_pointer"
-             fi
-             ;;
-  esac
+            *) # other systems are fine as far as I can tell
+               if test "$ENABLE_DEBUG" != yes -a "$ENABLE_PROFILE" != yes; then
+                 FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_fomit_frame_pointer"
+               fi
+               ;;
+    esac
+  fi
 
   if test "$GNU_GCC_IPA_RA_POSSIBLE_BUG" = yes; then
     FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_fno_ipa_ra"

--- a/configure.ac
+++ b/configure.ac
@@ -2001,6 +2001,10 @@ if test "$C_COMP_CLANG" != yes -a "$C_COMP_GNUC_VERSION" -ge 402000 -a "$C_COMP_
   GNU_GCC_MOVE_LOOP_INVARIANTS_POSSIBLE_BUG=yes
 fi
 
+if test "$C_COMP_CLANG" = yes -a "$C_COMP_CLANG_VERSION" -ge 1100000; then
+  OMIT_FRAME_POINTER_POSSIBLE_BUG=yes
+fi
+
 case "$target_os" in
   darwin*) # strangely this bug only appears on Mac OS
     if test "$C_COMP_CLANG" != yes -a "$C_COMP_GNUC_VERSION" -ge 600000 -a "$DASH_fno_ipa_ra" != "" -a "$ENABLE_SHARED" = yes -a "$ENABLE_C_OPT" != no; then
@@ -2228,17 +2232,19 @@ if test "$C_COMP_GNUC" = yes; then
     FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_freschedule_modulo_scheduled_loops"
   fi
 
-  case "$target_os" in
+  if test "$OMIT_FRAME_POINTER_POSSIBLE_BUG" != yes; then
+    case "$target_os" in
 
-     mingw*) # MinGW's setjmp seems to need the frame pointer
-             ;;
+       mingw*) # MinGW's setjmp seems to need the frame pointer
+               ;;
 
-          *) # other systems are fine as far as I can tell
-             if test "$ENABLE_DEBUG" != yes -a "$ENABLE_PROFILE" != yes; then
-               FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_fomit_frame_pointer"
-             fi
-             ;;
-  esac
+            *) # other systems are fine as far as I can tell
+               if test "$ENABLE_DEBUG" != yes -a "$ENABLE_PROFILE" != yes; then
+                 FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_fomit_frame_pointer"
+               fi
+               ;;
+    esac
+  fi
 
   if test "$GNU_GCC_IPA_RA_POSSIBLE_BUG" = yes; then
     FLAGS_OBJ_DYN="$FLAGS_OBJ_DYN$DASH_fno_ipa_ra"


### PR DESCRIPTION
Avoid using -fomit-frame-pointer on clang 11.0.0 and above as this causes a clang bug (see issue #415)