### PR TITLE
gsc: Add module-ref to module inputs during compilation

### DIFF
--- a/gsi/main.scm
+++ b/gsi/main.scm
@@ -508,16 +508,23 @@ usage-end
                             (exit-abnormally)))
 
                       (define (do-compile-file-to-target file opts output)
-                        (handling file)
-                        (or (if output
-                                (compile-file-to-target
-                                 file
-                                 options: opts
-                                 output: output)
-                                (compile-file-to-target
-                                 file
-                                 options: opts))
-                            (exit-abnormally)))
+                        (let* ((modref (##parse-module-ref file))
+                               (opts (if (##not modref)
+                                         opts
+                                         (##cons
+                                           (##list 'module-ref
+                                                   (##string->symbol file))
+                                           opts))))
+                          (handling file)
+                          (or (if output
+                                  (compile-file-to-target
+                                   file
+                                   options: opts
+                                   output: output)
+                                  (compile-file-to-target
+                                   file
+                                   options: opts))
+                              (exit-abnormally))))
 
                       (define (do-build-executable base obj-files output-filename)
                         (or (##build-executable


### PR DESCRIPTION
This change improves `gsc`'s handling of module reference inputs so that the `module-ref` option is properly set on those inputs at compilation time.  This ensures that the module will be given the right namespace in the compiled output.

The examples below were run with the following command line:

```
../../gambit/dist/bin/gsc -verbose -exe -o lib-test -nopreload . test-lib/a lib-test.scm 
```

Example `gsc` output for module `test-lib/a` **before** this change:

```
...
test-lib/a:
Parsing:
  "declare"
  "namespace"
  "namespace"
  a#do-stuff
  "namespace"

Compiling:
  a#do-stuff

Dumping:
  #<primitive a#>
  #<primitive a#do-stuff>

Compilation finished.
...
```

Example `gsc` output for module `test-lib/a` **after** this change:

```
test-lib/a:
Parsing:
  "declare"
  "namespace"
  "namespace"
  test-lib/a#do-stuff
  "namespace"

Compiling:
  test-lib/a#do-stuff

Dumping:
  #<primitive test-lib/a#>
  #<primitive test-lib/a#do-stuff>

Compilation finished.
```

Please let me know if there are any tests I can add or other similar improvements I should make in this file!