### PR TITLE
Copy config.guess and config.sub to ./boot before building gsc-boot

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -129,6 +129,8 @@ boot-most-recent-release-gsc-boot: fake_target
 	rm -rf boot
 	mkdir -p boot
 	$(GIT) archive tags/$(PACKAGE_VERSION) | (cd boot && tar xf -)
+	cp config.guess boot
+	cp config.sub boot
 	cd boot && \
 	./configure $(BOOTSTRAP_CONFIGURE_FLAGS) CC='$(C_COMPILER)' && \
 	$(MAKE) bootstrap


### PR DESCRIPTION
This change follows on from #520 by copying the updated `config.guess` and `config.sub` files to the `boot/` folder before building `gsc-boot`.  Since these updated files are not a part of the `v4.9.3` tag, they need to be updated before building on Windows 10.