### PR TITLE
Fix C compiler warnings (^ bitwise operator).

### DIFF
--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -5245,9 +5245,8 @@ ___stream_index *len_done;)
       else if (n == 0)
         {
           /* Check if the other part initiated a shutdown and we didn't reply */
-          if (SSL_get_shutdown (d->tls)
-              & SSL_RECEIVED_SHUTDOWN
-              ^ SSL_SENT_SHUTDOWN)
+          int shut = SSL_get_shutdown (d->tls);
+          if ((shut & SSL_RECEIVED_SHUTDOWN) && !(shut & SSL_SENT_SHUTDOWN))
             {
               clear_tls_error_queue();
               SSL_shutdown (d->tls);
@@ -5377,9 +5376,8 @@ ___stream_index *len_done;)
       else if (n == 0)
         {
           /* Check if the other part initiated a shutdown and we didn't reply */
-          if (SSL_get_shutdown (d->tls)
-              & SSL_RECEIVED_SHUTDOWN
-              ^ SSL_SENT_SHUTDOWN)
+          int shut = SSL_get_shutdown (d->tls);
+          if ((shut & SSL_RECEIVED_SHUTDOWN) && !(shut & SSL_SENT_SHUTDOWN))
             {
               clear_tls_error_queue();
               SSL_shutdown (d->tls);


### PR DESCRIPTION
When configured with OpenSSL I saw the following warnings:

```
os_io.c:5249:15: warning: '&' within '^' [-Wbitwise-op-parentheses]
              & SSL_RECEIVED_SHUTDOWN
              ^~~~~~~~~~~~~~~~~~~~~~~
os_io.c:5249:15: note: place parentheses around the '&' expression to silence this warning
              & SSL_RECEIVED_SHUTDOWN
              ^~~~~~~~~~~~~~~~~~~~~~~
os_io.c:5381:15: warning: '&' within '^' [-Wbitwise-op-parentheses]
              & SSL_RECEIVED_SHUTDOWN
              ^~~~~~~~~~~~~~~~~~~~~~~
os_io.c:5381:15: note: place parentheses around the '&' expression to silence this warning
              & SSL_RECEIVED_SHUTDOWN
              ^~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gambit/gambit/578)
<!-- Reviewable:end -->
