### PR TITLE
Fix invocation of gsc when building imported "_must-build_" modules on Windows

### DIFF
--- a/bin/makefile.in
+++ b/bin/makefile.in
@@ -232,7 +232,7 @@ six@exe@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsi/$(GSI_EXECUTABLE) six@exe@; \
 	else \
-	  echo "@gsi %*" > six@bat@; \
+	  echo "@%~dp0gsi %*" > six@bat@; \
 	fi
 
 gsi-script@bat@: makefile
@@ -240,7 +240,7 @@ gsi-script@bat@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsi/$(GSI_EXECUTABLE) gsi-script@bat@; \
 	else \
-	  echo "@gsi %*" > gsi-script@bat@; \
+	  echo "@%~dp0gsi %*" > gsi-script@bat@; \
 	fi
 
 gsc-script@bat@: makefile
@@ -248,7 +248,7 @@ gsc-script@bat@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsc/$(GSC_EXECUTABLE) gsc-script@bat@; \
 	else \
-	  echo "@gsc %*" > gsc-script@bat@; \
+	  echo "@%~dp0gsc %*" > gsc-script@bat@; \
 	fi
 
 six-script@bat@: makefile
@@ -256,7 +256,7 @@ six-script@bat@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsi/$(GSI_EXECUTABLE) six-script@bat@; \
 	else \
-	  echo "@gsi %*" > six-script@bat@; \
+	  echo "@%~dp0gsi %*" > six-script@bat@; \
 	fi
 
 scheme-srfi-0@bat@: makefile
@@ -264,7 +264,7 @@ scheme-srfi-0@bat@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsi/$(GSI_EXECUTABLE) scheme-srfi-0@bat@; \
 	else \
-	  echo "@gsi %*" > scheme-srfi-0@bat@; \
+	  echo "@%~dp0gsi %*" > scheme-srfi-0@bat@; \
 	fi
 
 scheme-r5rs@bat@: makefile
@@ -272,7 +272,7 @@ scheme-r5rs@bat@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsi/$(GSI_EXECUTABLE) scheme-r5rs@bat@; \
 	else \
-	  echo "@gsi %*" > scheme-r5rs@bat@; \
+	  echo "@%~dp0gsi %*" > scheme-r5rs@bat@; \
 	fi
 
 scheme-r4rs@bat@: makefile
@@ -280,7 +280,7 @@ scheme-r4rs@bat@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsi/$(GSI_EXECUTABLE) scheme-r4rs@bat@; \
 	else \
-	  echo "@gsi %*" > scheme-r4rs@bat@; \
+	  echo "@%~dp0gsi %*" > scheme-r4rs@bat@; \
 	fi
 
 scheme-ieee-1178-1990@bat@: makefile
@@ -288,7 +288,7 @@ scheme-ieee-1178-1990@bat@: makefile
 	if test "@bat@" = ""; then \
 	  $(LN_S) $(rootfromhere)/gsi/$(GSI_EXECUTABLE) scheme-ieee-1178-1990@bat@; \
 	else \
-	  echo "@gsi %*" > scheme-ieee-1178-1990@bat@; \
+	  echo "@%~dp0gsi %*" > scheme-ieee-1178-1990@bat@; \
 	fi
 
 bootstrap-pre:

--- a/lib/_module.scm
+++ b/lib/_module.scm
@@ -596,7 +596,7 @@
   (let* ((gsc-path
           (##path-expand
            (##string-append "gsc-script"
-                            ##os-exe-extension-string-saved)
+                            ##os-bat-extension-string-saved)
            (##path-normalize-directory-existing "~~bin")))
          (arguments
           (##list (##append-strings


### PR DESCRIPTION
This change fixes a couple of issues I encountered when building a project which imports a module that uses a `._must-build_` file to force compilation via `gsc` before it gets imported.

The first issue is that the `.bat` scripts generated by `bin\makefile.in` were not invoking `gsc` from the folder in which they live.  This results in the following error when importing the `_must-build_` module in `gsi`:

```
'gsc' is not recognized as an internal or external command,
operable program or batch file.
```

The fix is to use `~dp0` in the path to invoke `gsc`/`gsi` so that the batch file's execution path is used to invoke it's peer exe.  I've fixed all instances of this pattern in `bin\makefile.in`.

The second issue is that `gsc-script.bat` was being launched as `gsc-script.exe` in `##build-module-subprocess`, resulting in this error:

```
*** ERROR IN ##build-module-subprocess -- No such file or directory
(##run-subprocess
 "D:\\a\\crash-the-stack\\crash-the-stack\\gambit\\bin\\gsc-script.exe"
 '("-:=~~execdir\\..,~~lib=./gambit/lib,~~userlib=./lib" "-e" "(##begin (##m...
 #f
 #f
 #f)
```

The fix is to use `##os-bat-extension-string-saved` instead of `##os-exe-extension-string-saved` when building the name of `gsc-script`.  I've tested this on Linux too just to make sure that a `.bat` isn't added to the name on non-Windows platforms.
