### PR TITLE
Only send Gitter webhook on push events or PRs from this repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
-      if: ${{ failure() }}
+      if: failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
 
   Windows-msvc:
     runs-on: windows-latest
@@ -90,7 +90,7 @@ jobs:
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
-      if: ${{ failure() }}
+      if: failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
 
   Linux:
     runs-on: ubuntu-latest
@@ -106,7 +106,7 @@ jobs:
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
-      if: ${{ failure() }}
+      if: failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
 
   MacOS:
     runs-on: macos-latest
@@ -124,7 +124,7 @@ jobs:
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
-      if: ${{ failure() }}
+      if: failure() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
 
   ReportResult:
     runs-on: ubuntu-latest
@@ -134,4 +134,4 @@ jobs:
     steps:
     - name: Report Success to Gitter
       run: curl --data-urlencode "message=CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) passed" ${{ secrets.GITTER_URL }}
-      if: ${{ success() }}
+      if: success() && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)


### PR DESCRIPTION
Because GitHub Actions doesn't provide secrets to CI jobs initiated by pull requests from forks, the `GITTER_URL` secret doesn't get passed along to our webhook tasks causing them to fail for PRs from external contributors.  This change avoids running webhook tasks in that case so that the jobs don't fail.