### PR TITLE
Simplify CI patterns for code checkout and MSYS/MinGW invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         update: true
         cache: true
-        install: "autoconf git make texinfo mingw-w64-${{ matrix.arch }}-gcc mingw-w64-${{ matrix.arch }}-make mingw-w64-${{ matrix.arch }}-libwinpthread-git"
+        install: "autoconf git make tar texinfo mingw-w64-${{ matrix.arch }}-gcc mingw-w64-${{ matrix.arch }}-make mingw-w64-${{ matrix.arch }}-libwinpthread-git"
         msystem: ${{ matrix.msystem }}
 
     - name: Build
@@ -76,7 +76,7 @@ jobs:
       with:
         update: true
         cache: true
-        install: "autoconf make patch texinfo"
+        install: "autoconf make patch tar texinfo"
         msystem: MSYS
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - github-actions # TODO: Remove this before enabling on Gambit repo
 
 jobs:
   Windows-mingw:
@@ -21,34 +20,33 @@ jobs:
           - msystem: "MINGW32"
             arch: "i686"
 
+    defaults:
+      run:
+        shell: msys2 {0}
+
     steps:
     - uses: actions/checkout@v2
-
-    - name: Fetch Tags
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
 
     - name: Install MSYS2
       uses: eine/setup-msys2@v1
       with:
         update: true
         cache: true
-        install: "autoconf git make mingw-w64-${{ matrix.arch }}-gcc mingw-w64-${{ matrix.arch }}-make mingw-w64-${{ matrix.arch }}-libwinpthread-git"
-        path-type: inherit
+        install: "autoconf git make texinfo mingw-w64-${{ matrix.arch }}-gcc mingw-w64-${{ matrix.arch }}-make mingw-w64-${{ matrix.arch }}-libwinpthread-git"
         msystem: ${{ matrix.msystem }}
 
     - name: Build
-      shell: cmd
-      run: msys2 ./configure --enable-debug --enable-multiple-threaded-vms;make -j4; make modules
+      run: ./configure --enable-debug --enable-multiple-threaded-vms;make -j4; make modules
 
     # Only run tests for MinGW64 for now
     - name: Test
       if: ${{ matrix.msystem == 'MINGW64' }}
       shell: cmd
-      run: |
-        msys2 make check
+      run: make check
 
     - name: Build Gambit for Use
-      shell: msys2 {0}
       run: |
         mkdir dist
         export CFLAGS="-O0" # Avoid a segfault caused by GCC optimizations
@@ -70,17 +68,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Fetch Tags
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
 
     - name: Install MSYS2
       uses: eine/setup-msys2@v1
       with:
         update: true
         cache: true
-        install: "autoconf make patch"
-        path-type: inherit
+        install: "autoconf make patch texinfo"
         msystem: MSYS
 
     - name: Build
@@ -127,9 +123,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Fetch Tags
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
 
     - name: Build and Test
       run: ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j4 && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j4 && make check && make clean && ./configure --enable-ansi-c && make -j4 && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
@@ -157,9 +152,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Fetch Tags
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
 
     - name: Build and Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 0 # Checkout history and tags
 
     - name: Install MSYS2
       uses: eine/setup-msys2@v1
@@ -69,7 +69,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 0 # Checkout history and tags
 
     - name: Install MSYS2
       uses: eine/setup-msys2@v1
@@ -125,7 +125,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 0 # Checkout history and tags
 
     - name: Build and Test
       run: ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j4 && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j4 && make check && make clean && ./configure --enable-ansi-c && make -j4 && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
@@ -154,7 +154,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 0 # Checkout history and tags
 
     - name: Build and Test
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
         update: true
         cache: true
         install: "autoconf make patch tar texinfo"
+        path-type: inherit
         msystem: MSYS
 
     - name: Build


### PR DESCRIPTION
@eine left some helpful tips in issue #590, this PR implements them to simplify our CI jobs further.  I'm also adding `texinfo` as a dependency to be installed for Windows builds so that we can build `info` files in `make doc`.