### PR TITLE
Re-enable `path-type: inherit` in MSYS config for MinGW builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         update: true
         cache: true
         install: "autoconf git make tar texinfo mingw-w64-${{ matrix.arch }}-gcc mingw-w64-${{ matrix.arch }}-make mingw-w64-${{ matrix.arch }}-libwinpthread-git"
+        path-type: inherit
         msystem: ${{ matrix.msystem }}
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,12 +160,14 @@ jobs:
     - name: Build and Test
       run: |
         export CC=gcc-9
+        export CXX=g++-9
         ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j4 && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j4 && make check && make clean && ./configure --enable-ansi-c && make -j4 && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
 
     - name: Build Gambit for Use
       run: |
         mkdir dist
         export CC=gcc-9
+        export CXX=g++-9
         ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist && make -j4 && make modules && make install
         cd dist/
         tar -cvzf ../gambit-macos-x86_64.tar.gz ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
     - name: Build Gambit for Use
       run: |
         mkdir dist
-        # Avoid a segfault caused by GCC optimizations and statically link
-        # libwinpthread so that gsc/gsi.exe don't have to be run within MinGW
-        export CFLAGS="-O0 -static"
+        # Statically link libraries like libwinpthread so that
+        # gsc/gsi.exe don't have to be run within MinGW
+        export CFLAGS="-static"
         ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist;make -j4; make modules; make install
 
     - name: Upload Build Artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
     - name: Build Gambit for Use
       run: |
         mkdir dist
-        export CFLAGS="-O0" # Avoid a segfault caused by GCC optimizations
+        # Avoid a segfault caused by GCC optimizations and statically link
+        # libwinpthread so that gsc/gsi.exe don't have to be run within MinGW
+        export CFLAGS="-O0 -static"
         ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist;make -j4; make modules; make install
 
     - name: Upload Build Artifact


### PR DESCRIPTION
I noticed some errors about `findstr` not being found in MinGW builds, turns out this is because `gambuild-C` on Windows uses `findstr` to extract meta info from modules.  I'm turning `path-type: inherit` back on in MinGW builds so that Windows commands will be accessible in those builds.