### PR TITLE
Store output of 'make dist-boot' as artifact, build with processor count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         cd ..
 
     - name: Package Source
-      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+      run: make dist && find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
@@ -166,7 +166,7 @@ jobs:
     - name: Upload Source
       uses: actions/upload-artifact@v1
       with:
-        name: gambit-linux-x86_64-dist
+        name: gambit-dist
         path: gambit.tgz
 
     - name: Report Failure to Gitter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.16
         set PATH=%RUNNER_TEMP%\msys\msys64\usr\bin;%PATH%
-        msys2 ./configure --enable-c-opt=-Od --enable-debug CC="cl" && make -j`nproc` && make modules
+        msys2 ./configure --enable-c-opt=-Od --enable-debug CC="cl" && make -j%NUMBER_OF_PROCESSORS% && make modules
 
     - name: Test
       shell: cmd
@@ -116,7 +116,7 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.16
         mkdir dist
-        msys2 ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist CC="cl" && make -j`nproc` && make modules && make install
+        msys2 ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist CC="cl" && make -j%NUMBER_OF_PROCESSORS% && make modules && make install
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,20 @@ jobs:
         export CFLAGS="-static"
         ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist;make -j4; make modules; make install
 
+    - name: Package Source
+      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-win-mingw-${{ matrix.arch }}
         path: dist/
+
+    - name: Upload Source
+      uses: actions/upload-artifact@v1
+      with:
+        name: gambit-win-mingw-${{ matrix.arch }}-dist
+        path: gambit.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
@@ -112,11 +121,21 @@ jobs:
         mkdir dist
         msys2 ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist CC="cl";make -j4; make modules; make install
 
+    - name: Package Source
+      shell: msys2 {0}
+      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-win-msvc-x86_64
         path: dist/
+
+    - name: Upload Source
+      uses: actions/upload-artifact@v1
+      with:
+        name: gambit-win-msvc-x86_64-dist
+        path: gambit.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
@@ -141,11 +160,20 @@ jobs:
         tar -cvzf ../gambit-linux-x86_64.tar.gz ./
         cd ..
 
+    - name: Package Source
+      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-linux-x86_64
         path: gambit-linux-x86_64.tar.gz
+
+    - name: Upload Source
+      uses: actions/upload-artifact@v1
+      with:
+        name: gambit-linux-x86_64-dist
+        path: gambit.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
@@ -175,11 +203,20 @@ jobs:
         tar -cvzf ../gambit-macos-x86_64.tar.gz ./
         cd ..
 
+    - name: Package Source
+      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+
     - name: Upload Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-macos-x86_64
         path: gambit-macos-x86_64.tar.gz
+
+    - name: Upload Source
+      uses: actions/upload-artifact@v1
+      with:
+        name: gambit-macos-x64_64-dist
+        path: gambit.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         fetch-depth: 0 # Checkout history and tags
 
     - name: Install MSYS2
-      uses: eine/setup-msys2@v1
+      uses: msys2/setup-msys2@v1
       with:
         update: true
         cache: true
@@ -79,7 +79,7 @@ jobs:
         fetch-depth: 0 # Checkout history and tags
 
     - name: Install MSYS2
-      uses: eine/setup-msys2@v1
+      uses: msys2/setup-msys2@v1
       with:
         update: true
         cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         update: true
         cache: true
         install: "autoconf git make tar texinfo mingw-w64-${{ matrix.arch }}-gcc mingw-w64-${{ matrix.arch }}-make mingw-w64-${{ matrix.arch }}-libwinpthread-git"
-        path-type: inherit
         msystem: ${{ matrix.msystem }}
 
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Build
       run: |
-        ./configure --enable-debug --enable-multiple-threaded-vms
+        ./configure --enable-debug --enable-multiple-threaded-vms --enable-thread-system=win32
         make -j`nproc`
         make modules
 
@@ -55,8 +55,8 @@ jobs:
         mkdir dist
         # Statically link libraries like libwinpthread so that
         # gsc/gsi.exe don't have to be run within MinGW
-        ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist
         export CFLAGS="-static"
+        ./configure --enable-single-host --enable-thread-system=win32 --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist
         make -j`nproc`
         make modules
         make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,10 @@ jobs:
         msystem: ${{ matrix.msystem }}
 
     - name: Build
-      run: ./configure --enable-debug --enable-multiple-threaded-vms;make -j4; make modules
+      run: |
+        ./configure --enable-debug --enable-multiple-threaded-vms
+        make -j`nproc`
+        make modules
 
     # Only run tests for MinGW64 for now
     - name: Test
@@ -52,23 +55,17 @@ jobs:
         mkdir dist
         # Statically link libraries like libwinpthread so that
         # gsc/gsi.exe don't have to be run within MinGW
+        ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist
         export CFLAGS="-static"
-        ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist;make -j4; make modules; make install
-
-    - name: Package Source
-      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+        make -j`nproc`
+        make modules
+        make install
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-win-mingw-${{ matrix.arch }}
         path: dist/
-
-    - name: Upload Source
-      uses: actions/upload-artifact@v1
-      with:
-        name: gambit-win-mingw-${{ matrix.arch }}-dist
-        path: gambit.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
@@ -97,7 +94,7 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.16
         set PATH=%RUNNER_TEMP%\msys\msys64\usr\bin;%PATH%
-        msys2 ./configure --enable-c-opt=-Od --enable-debug CC="cl"; make -j4; make modules
+        msys2 ./configure --enable-c-opt=-Od --enable-debug CC="cl" && make -j`nproc` && make modules
 
     - name: Test
       shell: cmd
@@ -119,23 +116,13 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.16
         mkdir dist
-        msys2 ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist CC="cl";make -j4; make modules; make install
-
-    - name: Package Source
-      shell: msys2 {0}
-      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+        msys2 ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist CC="cl" && make -j`nproc` && make modules && make install
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-win-msvc-x86_64
         path: dist/
-
-    - name: Upload Source
-      uses: actions/upload-artifact@v1
-      with:
-        name: gambit-win-msvc-x86_64-dist
-        path: gambit.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
@@ -155,12 +142,14 @@ jobs:
         sudo apt-get install texinfo
 
     - name: Build and Test
-      run: ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j4 && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j4 && make check && make clean && ./configure --enable-ansi-c && make -j4 && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
+      run: |
+        export PROCS=`nproc`
+        ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j$PROCS && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j$PROCS && make check && make clean && ./configure --enable-ansi-c && make -j$PROCS && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
 
     - name: Build Gambit for Use
       run: |
         mkdir dist
-        ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist && make -j4 && make modules && make install
+        ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist && make -j`nproc` && make modules && make install
         cd dist/
         tar -cvzf ../gambit-linux-x86_64.tar.gz ./
         cd ..
@@ -196,32 +185,24 @@ jobs:
       run: |
         export CC=gcc-9
         export CXX=g++-9
-        ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j4 && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j4 && make check && make clean && ./configure --enable-ansi-c && make -j4 && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
+        export PROCS=`sysctl -n hw.physicalcpu`
+        ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j$PROCS && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j$PROCS && make check && make clean && ./configure --enable-ansi-c && make -j$PROCS && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
 
     - name: Build Gambit for Use
       run: |
         mkdir dist
         export CC=gcc-9
         export CXX=g++-9
-        ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist && make -j4 && make modules && make install
+        ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist && make -j`sysctl -n hw.physicalcpu` && make modules && make install
         cd dist/
         tar -cvzf ../gambit-macos-x86_64.tar.gz ./
         cd ..
-
-    - name: Package Source
-      run: make dist; find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-macos-x86_64
         path: gambit-macos-x86_64.tar.gz
-
-    - name: Upload Source
-      uses: actions/upload-artifact@v1
-      with:
-        name: gambit-macos-x64_64-dist
-        path: gambit.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
     # Only run tests for MinGW64 for now
     - name: Test
       if: ${{ matrix.msystem == 'MINGW64' }}
-      shell: cmd
       run: make check
 
     - name: Build Gambit for Use

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Build
       run: |
         ./configure --enable-debug --enable-multiple-threaded-vms --enable-thread-system=win32
+        echo "#undef HAVE_CLOCK_GETTIME" >> include/config.h
         make -j`nproc`
 
     # Only run tests for MinGW64 for now
@@ -52,10 +53,8 @@ jobs:
     - name: Build Gambit for Use
       run: |
         mkdir dist
-        # Statically link libraries like libwinpthread so that
-        # gsc/gsi.exe don't have to be run within MinGW
-        export CFLAGS="-static"
         ./configure --enable-single-host --enable-thread-system=win32 --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist
+        echo "#undef HAVE_CLOCK_GETTIME" >> include/config.h
         make -j`nproc`
         make modules
         make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,11 @@ jobs:
       with:
         fetch-depth: 0 # Checkout history and tags
 
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install texinfo
+
     - name: Build and Test
       run: ./configure --enable-debug --enable-multiple-threaded-vms && make clean && make -j4 && make check && make clean && ./configure --enable-debug --enable-multiple-threaded-vms --enable-cplusplus && make -j4 && make check && make clean && ./configure --enable-ansi-c && make -j4 && (cd tests; make test1) && (cd tests; make test2) && (cd tests; make test3) && (cd tests; make test4) && (cd tests; make test5)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,20 +154,20 @@ jobs:
         tar -cvzf ../gambit-linux-x86_64.tgz ./
         cd ..
 
-    - name: Package Source
-      run: make dist && find ./ -name 'gambit-v*.tgz' -exec cp {} gambit-dist.tgz \;
-
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-linux-x86_64
         path: gambit-linux-x86_64.tgz
 
+    - name: Package Source
+      run: make dist-boot
+
     - name: Upload Source
       uses: actions/upload-artifact@v1
       with:
-        name: gambit-dist
-        path: gambit-dist.tgz
+        name: boot
+        path: boot.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       run: |
         ./configure --enable-debug --enable-multiple-threaded-vms --enable-thread-system=win32
         make -j`nproc`
-        make modules
 
     # Only run tests for MinGW64 for now
     - name: Test
@@ -94,7 +93,7 @@ jobs:
       run: |
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 -vcvars_ver=14.16
         set PATH=%RUNNER_TEMP%\msys\msys64\usr\bin;%PATH%
-        msys2 ./configure --enable-c-opt=-Od --enable-debug CC="cl" && make -j%NUMBER_OF_PROCESSORS% && make modules
+        msys2 ./configure --enable-c-opt=-Od --enable-debug CC="cl" && make -j%NUMBER_OF_PROCESSORS%
 
     - name: Test
       shell: cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,23 +151,23 @@ jobs:
         mkdir dist
         ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist && make -j`nproc` && make modules && make install
         cd dist/
-        tar -cvzf ../gambit-linux-x86_64.tar.gz ./
+        tar -cvzf ../gambit-linux-x86_64.tgz ./
         cd ..
 
     - name: Package Source
-      run: make dist && find ./ -name 'gambit-v*.tgz' -exec cp {} gambit.tgz \;
+      run: make dist && find ./ -name 'gambit-v*.tgz' -exec cp {} gambit-dist.tgz \;
 
     - name: Upload Build Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-linux-x86_64
-        path: gambit-linux-x86_64.tar.gz
+        path: gambit-linux-x86_64.tgz
 
     - name: Upload Source
       uses: actions/upload-artifact@v1
       with:
         name: gambit-dist
-        path: gambit.tgz
+        path: gambit-dist.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}
@@ -195,14 +195,14 @@ jobs:
         export CXX=g++-9
         ./configure --enable-single-host --enable-gambitdir=~~execdir/.. --prefix=$(pwd)/dist && make -j`sysctl -n hw.physicalcpu` && make modules && make install
         cd dist/
-        tar -cvzf ../gambit-macos-x86_64.tar.gz ./
+        tar -cvzf ../gambit-macos-x86_64.tgz ./
         cd ..
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v1
       with:
         name: gambit-macos-x86_64
-        path: gambit-macos-x86_64.tar.gz
+        path: gambit-macos-x86_64.tgz
 
     - name: Report Failure to Gitter
       run: curl --data-urlencode "message=${{ github.job }} build of CI run [$GITHUB_RUN_ID](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed" -d level=error ${{ secrets.GITTER_URL }}


### PR DESCRIPTION
This change is the first step toward faster PR builds.  It uploads the output of `make dist` as an artifact called `gambit-dist.tgz` that can be downloaded from the latest successful CI build on `master` and applied to `boot/` in PR runs.  I'm almost done updating [`daviwil/download-gambit`](https://github.com/daviwil/download-gambit) to support downloading this artifact.