### PR TITLE
Add arm64 CPU type to support Apple M1 build type.

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -1156,7 +1156,7 @@ case $cpu-$vendor in
 		case $cpu in
 			1750a | 580 \
 			| a29k \
-			| aarch64 | aarch64_be \
+			| arm64 | aarch64 | aarch64_be \
 			| abacus \
 			| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] \
 			| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] \


### PR DESCRIPTION
OSX will return 'arm64-apple-darwin*' for the uname string
instead of using aarch64.  Compilation otherwise succeeds and
tests complete normally.

Fixes #662