### PR TITLE
Dockerfile for gambit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcc:9.3.0
+WORKDIR gambit_install
+COPY . .
+RUN make clean && ./configure --enable-single-host && make -j$(nproc) && make check && make modules && make doc && make install
+RUN ln -s /gambit_install/gsi/gsi /bin/gsi && ln -s /gambit_install/gsc/gsc /bin/gsc
+WORKDIR /workdir


### PR DESCRIPTION
# Installing gambit 

Installing gambit can be a bit of a pain sometimes, especially on windows or uncommon linux distributions. Having to compile it from scratch even for quick demonstrations can also be annoying. Also, sometimes it is useful to have multiple gambit versions on hand, in order to test regressions, etc. 

# Installing gambit using Docker

I made a Dockerfile to greatly simplify installing Gambit. Using docker, one can install gambit by doing 

```bash
docker pull velythyl/gambit:latest
```

This pulls the latest gambit version from my own dockerhub profile https://hub.docker.com/repository/docker/velythyl/gambit 

# Running gambit using docker

Then, gambit can by used by doing

```bash
docker run -it velythyl/gambit
```

# What it actually does

This command above will open an ubuntu container running locally, in which gsi and gsc are installed. This also means that one could alias `gsi` in their own shell to `docker run -i velythyl/gambit gsi`, and it would boot you directly into the gambit repl, as if it was installed on your own machine.

# Changing the docker image name (replacing "velythyl" by "gambit")

Of couse, the commands above use the image found on my own dockerhub. You might want to push images to a Gambit profile on dockerhub. To do so, follow the instructions bellow:

# Building the docker image
 
To generate the docker image once a new gambit release is ready, simply do

```bash
docker built -t gambit -t gambit/gambit:latest -t gambit/gambit:<gambit release version> .
docker push gambit/gambit
```

# Note:

I verified with @SamuelYvon that everything works fine :)