### PR TITLE
Fix too few arguments passed to open_long_path

### DIFF
--- a/lib/os_io.c
+++ b/lib/os_io.c
@@ -8690,7 +8690,7 @@ int *slave_fd_ptr;)
 #else
 
   *slave_fd_ptr = -1;
-  return *master_fd_ptr = open_long_path ("/dev/ptmx", O_RDWR | O_NOCTTY);
+  return *master_fd_ptr = open_long_path ("/dev/ptmx", O_RDWR | O_NOCTTY, 0);
 
 #endif
 #endif
@@ -8765,7 +8765,7 @@ int *slave_fd;)
   if (grantpt (master_fd) >= 0 &&
       unlockpt (master_fd) >= 0 &&
       (name = ptsname (master_fd)) != NULL &&
-      (fd = open_long_path (name, O_RDWR)) >= 0)
+      (fd = open_long_path (name, O_RDWR, 0)) >= 0)
     {
       int tmp;
 


### PR DESCRIPTION
I fixed the call to `open_long_path` that had too few arguments. The mode value passed is 0. It's ignored if the "oflag" doesn't contain `O_CREAT`.