### PR TITLE
Add some Floyd procedures from SRFI 1

### DIFF
--- a/lib/gambit#.scm
+++ b/lib/gambit#.scm
@@ -131,6 +131,7 @@ cfun-conversion-exception-procedure
 cfun-conversion-exception?
 char-foldcase
 circular-list
+circular-list?
 clear-bit-field
 close-port
 command-line
@@ -194,6 +195,7 @@ display-procedure-environment
 divide-by-zero-exception-arguments
 divide-by-zero-exception-procedure
 divide-by-zero-exception?
+dotted-list?
 drop
 emergency-exit
 eof-object
@@ -460,6 +462,7 @@ keyword-hash
 keyword?
 last
 last-pair
+length+
 length-mismatch-exception-arg-id
 length-mismatch-exception-arguments
 length-mismatch-exception-procedure
@@ -616,6 +619,7 @@ process-times
 processor-id
 processor?
 promise?
+proper-list?
 protocol-info
 protocol-info-aliases
 protocol-info-name

--- a/lib/gambit/list/list.scm
+++ b/lib/gambit/list/list.scm
@@ -101,12 +101,14 @@
   (macro-force-vars (obj)
     (##null? obj)))
 
-;; Floyd's tortoise and hare algorithm for cycle detection.
+;; Floyd's tortoise and hare algorithm for cycle detection
+
+;; https://en.wikipedia.org/wiki/Cycle_detection
 
 ;; These procedures may get into an infinite loop if another thread
 ;; mutates "lst" (if lst1 and lst2 each point to disconnected cycles).
 
-(define-procedure (floyd-tail lst)
+(##define (##possibly-cyclic-tail lst)
   (include "~~lib/gambit/prim/prim#.scm") ;; map fx+ to ##fx+, etc
   (let loop ((fast lst) (slow lst))
     (macro-force-vars (fast)
@@ -126,12 +128,12 @@
                     (else
                      fast))))))))
 
-(define-procedure (floyd-length lst)
+(##define (##possibly-cyclic-length lst)
   (include "~~lib/gambit/prim/prim#.scm") ;; map fx+ to ##fx+, etc
   (let loop ((len 0) (fast lst) (slow lst))
     (macro-force-vars (fast)
       (cond ((null? fast)
-             (* 2 len))
+             (fx* 2 len))
             ((not (pair? fast))
              #f)
             (else
@@ -147,20 +149,20 @@
                         ;; the list.
                         #f)
                        ((null? fast)
-                        (+ 1 (* 2 len)))
+                        (fx+ 1 (fx* 2 len)))
                        ((not (pair? fast))
                         #f)
                        (else
-                        (loop (+ len 1) (cdr fast) (cdr slow)))))))))))
+                        (loop (fx+ len 1) (cdr fast) (cdr slow)))))))))))
 
 (define-procedure (proper-list? (lst object))
-  (null? (floyd-tail lst)))
+  (null? (##possibly-cyclic-tail lst)))
 
 (define-procedure (circular-list? (lst object))
-  (pair? (floyd-tail lst)))
+  (pair? (##possibly-cyclic-tail lst)))
 
 (define-procedure (dotted-list? (lst object))
-  (let ((tail (floyd-tail lst)))
+  (let ((tail (##possibly-cyclic-tail lst)))
     (not (or (null? tail) (pair? tail)))))
 
 (define-prim (##list? lst)
@@ -197,7 +199,7 @@
             n)))))
 
 (define-procedure (length+ (lst object))
-  (floyd-length lst))
+  (##possibly-cyclic-length lst))
 
 (define-prim (##append2 lst1 lst2)
 

--- a/lib/gambit/list/list.scm
+++ b/lib/gambit/list/list.scm
@@ -101,28 +101,70 @@
   (macro-force-vars (obj)
     (##null? obj)))
 
-(define-prim (##list? lst)
+;; Floyd's tortoise and hare algorithm for cycle detection.
 
+;; These procedures may get into an infinite loop if another thread
+;; mutates "lst" (if lst1 and lst2 each point to disconnected cycles).
+
+(define-procedure (floyd-tail lst)
   (include "~~lib/gambit/prim/prim#.scm") ;; map fx+ to ##fx+, etc
-
-  ;; This procedure may get into an infinite loop if another thread
-  ;; mutates "lst" (if lst1 and lst2 each point to disconnected cycles).
-
-  (let loop ((lst1 lst) (lst2 lst))
-    (macro-force-vars (lst1)
-      (if (not (pair? lst1))
-          (null? lst1)
-          (let ((lst1 (cdr lst1)))
-            (macro-force-vars (lst1 lst2)
-              (cond ((eq? lst1 lst2)
-                     #f)
-                    ((not (pair? lst2))
-                     ;; this case is possible if other threads mutate the list
-                     (null? lst2))
-                    ((pair? lst1)
-                     (loop (cdr lst1) (cdr lst2)))
+  (let loop ((fast lst) (slow lst))
+    (macro-force-vars (fast)
+      (if (not (pair? fast))
+          fast
+          (let ((fast (cdr fast)))
+            (macro-force-vars (fast slow)
+              (cond ((eq? fast slow)
+                     ;; Cycle detected. Return some pair in the cycle.
+                     fast)
+                    ((not (pair? slow))
+                     ;; This case is possible if other threads mutate
+                     ;; the list.
+                     slow)
+                    ((pair? fast)
+                     (loop (cdr fast) (cdr slow)))
                     (else
-                     (null? lst1)))))))))
+                     fast))))))))
+
+(define-procedure (floyd-length lst)
+  (include "~~lib/gambit/prim/prim#.scm") ;; map fx+ to ##fx+, etc
+  (let loop ((len 0) (fast lst) (slow lst))
+    (macro-force-vars (fast)
+      (cond ((null? fast)
+             (* 2 len))
+            ((not (pair? fast))
+             #f)
+            (else
+             (let ((fast (cdr fast)))
+               (macro-force-vars (fast slow)
+                 (cond ((eq? fast slow)
+                        ;; Cycle detected.
+                        #f)
+                       ((null? slow)
+                        len)
+                       ((not (pair? slow))
+                        ;; This case is possible if other threads mutate
+                        ;; the list.
+                        #f)
+                       ((null? fast)
+                        (+ 1 (* 2 len)))
+                       ((not (pair? fast))
+                        #f)
+                       (else
+                        (loop (+ len 1) (cdr fast) (cdr slow)))))))))))
+
+(define-procedure (proper-list? (lst object))
+  (null? (floyd-tail lst)))
+
+(define-procedure (circular-list? (lst object))
+  (pair? (floyd-tail lst)))
+
+(define-procedure (dotted-list? (lst object))
+  (let ((tail (floyd-tail lst)))
+    (not (or (null? tail) (pair? tail)))))
+
+(define-prim (##list? lst)
+  (proper-list? lst))
 
 (define-prim (list? lst)
   (##list? lst))
@@ -153,6 +195,9 @@
           (loop (cdr x) (fx+ n 1))
           (macro-check-list x 1 (length lst)
             n)))))
+
+(define-procedure (length+ (lst object))
+  (floyd-length lst))
 
 (define-prim (##append2 lst1 lst2)
 

--- a/lib/gambit/list/list.sld
+++ b/lib/gambit/list/list.sld
@@ -51,8 +51,10 @@ cdddr
 cddr
 cdr
 circular-list
+circular-list?
 cons
 cons*
+dotted-list?
 drop
 fold
 fold-right
@@ -61,6 +63,7 @@ iota
 last
 last-pair
 length
+length+
 list
 list-copy
 list-ref
@@ -78,6 +81,7 @@ memq
 memv
 null?
 pair?
+proper-list?
 reverse
 reverse!
 set-car!


### PR DESCRIPTION
To start off, here are three list classification procedures and the cycle-aware `length+` procedure from SRFI 1. Does this look reasonable? Coding style can probably be improved.

Once these procedures are OK, we can merge them, or I can add all the SRFI 1 stuff by pushing more commits to the same PR.