### PR TITLE
Done 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ doc/gambit.pdf
 doc/gambit.pg
 doc/gambit.toc
 doc/gambit.tp
+doc/gambit.tsv
 doc/gambit.txt
 doc/gambit.vr
 doc/makefile

--- a/bin/gambdoc.unix.in
+++ b/bin/gambdoc.unix.in
@@ -2,11 +2,16 @@
 
 # Script parameters are passed in the following environment variables:
 #   GAMBITDIR_DOC
-#   GAMBDOC_ARG1_PARAM
-#   GAMBDOC_ARG2_PARAM
-#   GAMBDOC_ARG3_PARAM
-#   GAMBDOC_ARG4_PARAM
+#   GAMBDOC_ARG1_PARAM -- must be "help"
+#   GAMBDOC_ARG2_PARAM -- entry
+#   GAMBDOC_ARG3_PARAM -- index
+#   GAMBDOC_ARG4_PARAM -- prefer this web browser over the default choices
 #   ...
+
+# Exit code:
+#   0  - entry found and displayed
+#   1  - entry not found in index
+#   >1 - error
 
 # echo GAMBITDIR_DOC = "${GAMBITDIR_DOC}"
 # echo GAMBDOC_ARG1_PARAM = "${GAMBDOC_ARG1_PARAM}"
@@ -27,16 +32,9 @@ find_in_path() # exe-name, sets `$exe'
 
 find_browser() # sets `$exe'
 {
-  if [ "@HELP_BROWSER@" != "" ]; then
-    browser_list="@HELP_BROWSER@"
-  else
-    browser_list="lynx firefox mozilla netscape osascript chrome chromium chromium-browser"
-  fi
-
-  browser_list="${GAMBDOC_ARG3_PARAM} $browser_list"
-
+  browser_list="${GAMBDOC_ARG4_PARAM} lynx firefox mozilla netscape osascript chrome chromium chromium-browser"
   for b in $browser_list; do
-    if find_in_path $b; then
+    if find_in_path "$b"; then
       browser=$b
       return 0
     fi
@@ -44,28 +42,45 @@ find_browser() # sets `$exe'
   return 1
 }
 
-operation_help() # sets `$exe'
+open_url_osascript()
 {
-  if find_browser; then
-    url="file://${GAMBITDIR_DOC}/gambit.html#${GAMBDOC_ARG4_PARAM}"
-    case "$browser" in
-      osascript ) $exe <<EOF ;;
+  $exe <<EOF
 tell application "Safari"
     open location "$url"
 end tell
 EOF
-              * ) $exe $url ;;
-    esac
-  else
+}
+
+open_url()
+{
+  url="$1"
+  if ! find_browser; then
     echo "*** WARNING -- none of these browsers can be found to view the documentation:"
     echo "***            $browser_list"
+    exit 2
+  fi
+  case "$browser" in
+    osascript) open_url_osascript "$url";;
+    *) $exe "$url";;
+  esac
+}
+
+operation_help() # sets `$exe'
+{
+  entry="$GAMBDOC_ARG2_PARAM"
+  index="$GAMBDOC_ARG3_PARAM"
+  pattern="$(printf '\t%s\t%s' "$index" "$entry")"
+  tsv_file="${GAMBITDIR_DOC}/gambit.tsv"
+  where="$(grep -F -- "$pattern" <"$tsv_file" | head -n 1 | cut -f 1)"
+  if test -z "$where"; then
     exit 1
   fi
+  open_url "file://${GAMBITDIR_DOC}/${where}"
 }
 
 if [ "${GAMBDOC_ARG1_PARAM}" = "help" ]; then
   operation_help
 else
-  echo "*** WARNING -- unsupported operation: ${GAMBDOC_ARG1_PARAM}"
-  exit 1
+  echo "*** WARNING -- unsupported operation: \"${GAMBDOC_ARG1_PARAM}\""
+  exit 2
 fi

--- a/doc/makefile.in
+++ b/doc/makefile.in
@@ -87,7 +87,7 @@ gambit.info gambit.info-1 gambit.info-2 gambit.info-3
 
 DISTFILES = $(RCFILES) $(GENDISTFILES)
 
-INSTFILES_DOC = gambit.pdf gambit*.html gambit.txt
+INSTFILES_DOC = gambit.pdf gambit*.html gambit.tsv gambit.txt
 INSTFILES_INFO = gambit.info*
 INSTFILES_MAN = gsi.1
 
@@ -271,7 +271,7 @@ clean-pre: mostlyclean-pre
 
 clean-post clean-post-nonrec: mostlyclean-post-nonrec
 	rm -f *.aux *.cp *.cps *.dvi *.fn *.fns *.ky *.log *.pg \
-	  *.toc *.tp *.vr *.cm *.fl *.op *.tmp
+	  *.toc *.tp *.tsv *.vr *.cm *.fl *.op *.tmp
 
 distclean-pre: clean-pre
 

--- a/doc/makefile.in
+++ b/doc/makefile.in
@@ -105,7 +105,7 @@ pdf: gambit.pdf
 
 ps: gambit.ps
 
-html: gambit.html
+html: gambit.html gambit.tsv
 
 txt: gambit.txt
 
@@ -118,8 +118,8 @@ gambit.ps: gambit.pdf
 gambit.pdf: gambit.txi version.txi
 	(cd $(srcdir) && cd $(srcdir) && $(TEXI2DVI) -p gambit.txi) || (echo "*** $@ could not be built (perhaps $(TEXI2DVI) is not installed?)" > $@)
 
-gambit.html: gambit.txi
-	(cd $(srcdir) && $(TEXI2HTML) -def-table gambit.txi) || (echo "*** $@ could not be built (perhaps $(TEXI2HTML) is not installed?)" > $@)
+gambit.html gambit.tsv: gambit.txi
+	(cd $(srcdir) && $(TEXI2HTML) --idx-sum --def-table gambit.txi) || (echo "*** $@ could not be built (perhaps $(TEXI2HTML) is not installed?)" > $@)
 
 gambit.txt: gambit.txi
 	(cd $(srcdir) && $(MAKEINFO) --no-split --no-headers --output gambit.txt gambit.txi) || (echo "*** $@ could not be built (perhaps $(MAKEINFO) is not installed?)" > $@)

--- a/doc/texi2html
+++ b/doc/texi2html
@@ -5610,9 +5610,19 @@ $definition_category      = \&t2h_default_definition_category;
 $definition_index_entry   = \&t2h_default_definition_index_entry;
 $copying_comment          = \&t2h_default_copying_comment;
 $documentdescription      = \&t2h_default_documentdescription;
-$index_summary_file_entry = \&t2h_default_index_summary_file_entry;
-$index_summary_file_end   = \&t2h_default_index_summary_file_end;
-$index_summary_file_begin = \&t2h_default_index_summary_file_begin;
+
+###GAMBIT###
+#
+# Using custom versions of these functions to dump the index in the
+# same format as `makeinfo --internal-links`.
+#
+#$index_summary_file_entry = \&t2h_default_index_summary_file_entry;
+#$index_summary_file_end   = \&t2h_default_index_summary_file_end;
+#$index_summary_file_begin = \&t2h_default_index_summary_file_begin;
+$index_summary_file_entry = \&gambit_index_summary_file_entry;
+$index_summary_file_end   = \&gambit_index_summary_file_end;
+$index_summary_file_begin = \&gambit_index_summary_file_begin;
+
 $empty_line               = \&t2h_default_empty_line;
 $unknown                  = \&t2h_default_unknown;
 $unknown_style            = \&t2h_default_unknown_style;
@@ -7637,6 +7647,60 @@ sub t2h_default_cartouche($$)
     }
     return '';
 } 
+
+###GAMBIT### added this variable
+#
+# texi2html writes its default index into multiple files, but we write
+# it all into one file like makeinfo does. First time we open the
+# file, we overwrite it; thereafter we append to it.
+#
+our $gambit_index_summary_has_begun = 0;
+
+###GAMBIT### added this function
+sub gambit_index_summary_file_entry ($$$$$$$$$)
+{
+    my $index_name = shift;
+    my $key = shift;
+    my $origin_href = shift;
+    my $entry = shift;
+    my $texi_entry = shift;
+    my $element_href = shift;
+    my $element_text = shift;
+    my $is_printed = shift;
+    my $manual_name = shift;
+
+    print IDXFILE $origin_href . "\t" . $index_name . "\t" . $key . "\n";
+}
+
+###GAMBIT### added this function
+sub gambit_index_summary_file_begin($$$)
+{
+    my $name = shift;
+    my $is_printed = shift;
+    my $manual_name = shift;
+
+    my $open_mode = ">";
+    if (our $gambit_index_summary_has_begun) {
+        $open_mode = ">>";
+    }
+    our $gambit_index_summary_has_begun = 1;
+    my $tsv_file =
+        $Texi2HTML::THISDOC{'destination_directory'} .
+        $Texi2HTML::THISDOC{'file_base_name'} .
+        ".tsv";
+    open(IDXFILE, $open_mode, $tsv_file)
+        || die "Can't open $tsv_file for writing: $!\n";
+}
+
+###GAMBIT### added this function
+sub gambit_index_summary_file_end($$$)
+{
+    my $name = shift;
+    my $is_printed = shift;
+    my $manual_name = shift;
+
+    close (IDXFILE);
+}
 
 # key:          
 # origin_href:  


### PR DESCRIPTION
This patch is work-in-progress and is done on top of PR #697.

Adapts `gambdoc.unix.in` and the help procedures in `lib/_repl.scm` to work with the TSV index.

This doesn't properly handle the case where gambdoc is asked to look for remote documentation on gambitscheme.org; there's enough work as it is that I thought I'd ask for a review before doing that.