### PR TITLE
Fix gai_code_to_string type error when compiling under MINGW with --enable-cplusplus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ bin/scheme-r5rs.bat
 bin/scheme-srfi-0
 bin/scheme-srfi-0.bat
 bin/six
+bin/six.bat
 bin/six.exe
 bin/six-script
 bin/six-script.bat
@@ -175,6 +176,7 @@ prebuilt/windows/build-phase2
 bench/makefile
 contrib/GambitREPL/makefile
 contrib/makefile
+contrib/try/makefile
 contrib/xactlog/makefile
 githooks/makefile
 misc/makefile

--- a/lib/os_base.c
+++ b/lib/os_base.c
@@ -1142,7 +1142,11 @@ ___HIDDEN const char *gai_code_to_string
         (code)
 int code;)
 {
+#ifdef ___OS_WIN32
+  return gai_strerrorA (code);
+#else
   return gai_strerror (code);
+#endif
 }
 
 


### PR DESCRIPTION
gambit/gambit#635

The implementation for gai_strerror seems to vary on Windows/MINGW, it can return a string encoded as UTF-16 depending on #define UNICODE.