### PR TITLE
fixing geiser:load-file

### DIFF
--- a/lib/_geiser/_geiser.scm
+++ b/lib/_geiser/_geiser.scm
@@ -13,6 +13,7 @@
 
 (##namespace ("_geiser#"))                ;; in _geiser#
 (##include "~~lib/gambit/prim/prim#.scm") ;; map fx+ to ##fx+, etc
+(##namespace ("" load))                   ;; a non-primitive
 (##include "~~lib/_gambit#.scm")          ;; for macro-check-string,
                                           ;; macro-absent-obj, etc
 


### PR DESCRIPTION
The load function wasn't properly imported into the _geiser-namespace,
thus load-file didn't correctly.
I wonder if there is a reason (besides speed) why the code uses only primitive functions,
which load clearly is not.
