### PR TITLE
Changes to SIX parser and expander to support the Python FFI.

### DIFF
--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -14637,8 +14637,8 @@
                                       (wrap-identifier re start-pos tok)
                                       expr1)))))
            ((eq? tok2 'as)
-            (let ((as-name (get-token re #f #f))
-                  (tok3 (get-token re #t #f)))
+            (let* ((as-name (get-token re #f #f))
+                   (tok3 (get-token re #t #f)))
               (cond
                ((eq? tok3 |token.;-auto|)
                 (cont re
@@ -15430,8 +15430,8 @@
                                               start-pos
                                               'six.import expr)))))
             ((eq? tok 'from)
-             (let ((tok (get-token re #f #f))
-                   (tok1 (get-token re #f #f)))
+             (let* ((tok (get-token re #f #f))
+                    (tok1 (get-token re #f #f)))
                (if (eq? tok1 'import)
                    (let ((tok2 (get-token re #f #f)))
                      (if (eq? tok2 op.*)

--- a/lib/_six/python#.scm
+++ b/lib/_six/python#.scm
@@ -1,0 +1,23 @@
+;;;============================================================================
+
+;;; File: "python#.scm"
+
+;;; Copyright (c) 2020-2022 by Marc Feeley, All Rights Reserved.
+;;; Copyright (c) 2021-2022 by Marc-André Bélanger, All Rights Reserved.
+
+;;;============================================================================
+
+;; Implementation of the six.infix special form for Python.
+
+(##namespace ("_six/python#"
+
+six.infix
+
+))
+
+(##define-syntax six.infix
+  (lambda (src)
+    (import _six/six-expand)
+    (six.infix-python-expand src)))
+
+;;;============================================================================

--- a/lib/_six/python.scm
+++ b/lib/_six/python.scm
@@ -1,0 +1,26 @@
+;;;============================================================================
+
+;;; File: "python.scm"
+
+;;; Copyright (c) 2020-2022 by Marc Feeley, All Rights Reserved.
+;;; Copyright (c) 2021-2022 by Marc-André Bélanger , All Rights Reserved.
+
+;;;============================================================================
+
+;; Miscellaneous definitions needed at run time to support the
+;; six.infix special form for Python.
+
+(##supply-module _six/python)
+
+(##namespace ("_six/python#"))            ;; in _six/python#
+(##include "~~lib/gambit/prim/prim#.scm") ;; map fx+ to ##fx+, etc
+(##include "~~lib/_gambit#.scm")          ;; for macro-check-procedure,
+                                          ;; macro-absent-obj, etc
+
+(##include "python#.scm")
+
+(declare (extended-bindings)) ;; ##fx+ is bound to fixnum addition, etc
+(declare (not safe))          ;; claim code has no type errors
+(declare (block))             ;; claim no global is assigned
+
+;;;============================================================================

--- a/lib/_six/python.sld
+++ b/lib/_six/python.sld
@@ -15,7 +15,6 @@
 
   (include "python#.scm")
   (begin
-    ;; (##include "python#.scm")
     (##include "python.scm")))
 
 ;;;============================================================================

--- a/lib/_six/python.sld
+++ b/lib/_six/python.sld
@@ -1,0 +1,21 @@
+;;;============================================================================
+
+;;; File: "python.sld"
+
+;;; Copyright (c) 2020-2022 by Marc Feeley, All Rights Reserved.
+;;; Copyright (c) 2021-2022 by Marc-André Bélanger, All Rights Reserved.
+
+;;;============================================================================
+
+;;; Python FFI based on SIX.
+
+(define-library (python)
+
+  (export six.infix)
+
+  (include "python#.scm")
+  (begin
+    ;; (##include "python#.scm")
+    (##include "python.scm")))
+
+;;;============================================================================

--- a/lib/_six/six-expand#.scm
+++ b/lib/_six/six-expand#.scm
@@ -2,7 +2,8 @@
 
 ;;; File: "six-expand#.scm"
 
-;;; Copyright (c) 2020-2021 by Marc Feeley, All Rights Reserved.
+;;; Copyright (c) 2020-2022 by Marc Feeley, All Rights Reserved.
+;;; Copyright (c) 2022 by Marc-André Bélanger, All Rights Reserved.
 
 ;;;============================================================================
 
@@ -10,7 +11,8 @@
 
 (##namespace ("_six/six-expand#"
 
-six.infix-js-expand ;; currently only JavaScript is supported
+six.infix-js-expand
+six.infix-python-expand
 
 ))
 

--- a/lib/_six/six-expand.scm
+++ b/lib/_six/six-expand.scm
@@ -498,8 +498,6 @@
                                      body)))
                 `((##py-function-memoized ',(box def)) ;; literal box
                   ,@(map cdr params)))))))))
-                ;; `((python-eval ,def)
-                ;;   ,@(map cdr params)))))))))
 
 (define (six->target ast-src target)
   (case target
@@ -554,12 +552,8 @@
                                 ((1)
                                  (list target-op
                                        (infix (car rest) 1 inner-op)))
-                                 ;;                                ((2)
-                                 ;; (list (infix (car rest) 0 inner-op)
-                                 ;;       target-op
-                                 ;;       (infix (cadr rest) 1 inner-op)))
                                 ((2)
-                                ;; Hack to handle six.x=y assignments only for python
+                                ;; Handle six.x=y assignments for Python
                                 (if (and (eq? (conversion-ctx-target cctx) 'python)
                                          (not (conversion-ctx-incall cctx))
                                          (equal? target-op "="))


### PR DESCRIPTION
This commit presents changes to the SIX parser (`lib/_io.scm`) and expander (`lib/_six`) to support the upcoming Python FFI module.