### PR TITLE
Fix http module

### DIFF
--- a/lib/_http/_http.scm
+++ b/lib/_http/_http.scm
@@ -227,7 +227,7 @@
     (if (not uri)
       (raise (macro-make-http-exception
                (string-append "Invalid url '" url "'")))
-      (let* ((scheme (uri-scheme uri))
+      (let* ((scheme (or (uri-scheme uri) (raise (macro-make-http-exception "No scheme"))))
              (host+port
               (##string-split-at-char (or (uri-authority uri)
                                           (raise (macro-make-http-exception "No authority"))) #\:))

--- a/lib/_http/_http.scm
+++ b/lib/_http/_http.scm
@@ -229,7 +229,8 @@
                (string-append "Invalid url '" url "'")))
       (let* ((scheme (uri-scheme uri))
              (host+port
-              (##string-split-at-char (uri-authority uri) #\:))
+              (##string-split-at-char (or (uri-authority uri)
+                                          (raise (macro-make-http-exception "No authority"))) #\:))
              (tls-context (cond
                             ((string=? scheme "https")
                              (make-tls-context))

--- a/lib/_http/test/test.scm
+++ b/lib/_http/test/test.scm
@@ -115,7 +115,7 @@
                                  (define (handle-request version attributes)
                                    (let ((path (uri-path uri)))
                                      (cond
-                                       ((##string-prefix? path "/identity")
+                                       ((##string-prefix? "/identity" path)
                                         (display "HTTP/1.1 200 ok\r\nContent-Type: text/plain\r\nContent-Length: " conn)
                                         (display (string-length path) conn)
                                         (display "\r\n\r\n" conn)
@@ -125,7 +125,7 @@
 
                                         (loop (read serv-port)))
 
-                                       ((##string-prefix? path "/chunked")
+                                       ((##string-prefix? "/chunked" path)
                                         (display "HTTP/1.1 200 ok\r\nContent-Type: text/plain\r\nTransfer-Encoding: chunked\r\n\r\n" conn)
                                         (let ((msglen (string-length path)))
                                           (let loop2 ((i 0))
@@ -145,7 +145,7 @@
 
                                                 (loop (read serv-port)))))))
 
-                                       ((string=? path "/close")
+                                       ((string=? "/close" path)
                                         ;; return empty body
                                         (display "HTTP/1.1 200 ok\r\nContent-Length: 0\r\n\r\n" conn)
                                         (force-output conn)
@@ -217,5 +217,9 @@
 
     (lambda ()
       (thread-join! (vector-ref http-server 1) 1))))
+
+;; Invalid URL
+(test-error (http-get "//localhost"))
+(test-error (http-get "localhost"))
 
 ;;;============================================================================


### PR DESCRIPTION
- The unit test of the `_http` module was broken. The parameters to `##string-prefix?` were passed in the wrong order.
- Added two tests for invalid URL
- Add URI validation to avoid `http-get` crashing on invalid URL.