### PR TITLE
Add support for IBM System/390 and Z/Architecture.

### DIFF
--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -443,11 +443,27 @@
 #endif
 #endif
 
+#ifndef ___CPU_s390
+
+#ifdef __s390__
+#define ___CPU_s390
+#else
+#ifdef __s390x__
+#define ___CPU_s390
+#else
+#ifdef __zarch__
+#define ___CPU_s390
+#endif
+#endif
+#endif
+
+#endif
+
 /*
  * Determine the byte order endianness based on the processor type.
- * We assume that all processors are little-endian, except the sparc and
- * m68k.  The PowerPC, MIPS, ARM and Itanium can be either big-endian or
- * little-endian so extra tests are needed.
+ * We assume that all processors are little-endian, except the sparc,
+ * m68k, and s390.  The PowerPC, MIPS, ARM and Itanium can be either
+ * big-endian or little-endian so extra tests are needed.
  */
 
 #ifndef ___BIG_ENDIAN
@@ -481,6 +497,10 @@
 #endif
 
 #ifdef ___CPU_sparc
+#define ___BIG_ENDIAN
+#endif
+
+#ifdef ___CPU_s390
 #define ___BIG_ENDIAN
 #endif
 


### PR DESCRIPTION
This was initially tested in QEMU.

```
make[1]: Entering directory '/gambit-4.9.4/tests'
------------ TEST 1 (debugging support)
../gsi/gsi -:~~bin=../bin,~~lib=../lib,~~include=../include -f debug.scm > test1.out
diff test1.ok test1.out && rm -f test1.out
------------ TEST 2 (error handling)
../gsi/gsi -:m1,h5000,~~bin=../bin,~~lib=../lib,~~include=../include -f error.scm < error.scm > test2.out
diff test2.ok test2.out && rm -f test2.out
------------ TEST 3 (interpreter and library functions)
../gsi/gsi -:r4rs,~~bin=../bin,~~lib=../lib,~~include=../include -f -e '(begin (load "r4rstest.scm") (test-cont) (test-sc4) (test-delay) (exit))' > test3.out
diff test3.ok test3.out && rm -f test3.out tmp*
------------ TEST 4 (interpreter running an application)
rm -f mix.o
../gsi/gsi -:~~bin=../bin,~~lib=../lib,~~include=../include -f mix.scm > test4.out
10.868058000000001 secs elapsed cpu time
heartbeat frequency = 247.05425753156632 Hz
*** possible problem: expected heartbeat frequency = 1000. Hz
diff test4.ok test4.out && rm -f test4.out
------------ TEST 5 (compiler generating C code)
rm -f mix.c
../gsc/gsc -:~~bin=../bin,~~lib=../lib,~~include=../include -f -c -nb-gvm-regs 5 -nb-arg-regs 3 mix.scm
diff test5.ok mix.c
------------ TEST 6 (link and execute the code generated)
rm -f mix_.c mix.o mix_.o mix
../gsc/gsc -:~~bin=../bin,~~lib=../lib,~~include=../include -f -c mix.scm
../gsc/gsc -:~~bin=../bin,~~lib=../lib,~~include=../include -f -warnings -o mix -exe mix.c
./mix -:m5000 > test6.out
.9045390000000001 secs elapsed cpu time
heartbeat frequency = 254.27317119549292 Hz
*** possible problem: expected heartbeat frequency = 1000. Hz
diff test6.ok test6.out && \
  rm -f test6.out mix.c mix_.c mix.o mix_.o mix
------------ TEST 7 (memory management and C-interface)
rm -f mem.c mem_.c mem.o mem_.o mem
../gsc/gsc -:~~bin=../bin,~~lib=../lib,~~include=../include -f -warnings -o mem -exe mem.scm
./mem -:m1,h5000 > test7.out
diff test7.ok test7.out && \
  rm -f test7.out mem.c mem_.c mem.o mem_.o mem
------------ TEST 8 (use C-interface to implement a Scheme server)
rm -f server.c server_.c server.o server_.o \
  client.o client
../gsc/gsc -:~~bin=../bin,~~lib=../lib,~~include=../include -f -warnings -exe -cc-options "-D___LIBRARY" -o client client.c server.scm
./client > test8.out
diff -w test8.ok test8.out && \
  rm -f test8.out client
------------ TEST 9 (dynamic compilation and loading of a module)
rm -rf mem.o mem.o*
../gsc/gsc -:~~bin=../bin,~~lib=../lib,~~include=../include -f -warnings mem.scm
../gsi/gsi -:m1,h5000 -f mem.o1 > test9.out
diff test9.ok test9.out && rm -f test9.out mem.o mem.o1
------------ TEST 10 (consistency of runtime library exports)
rm -rf mem.o mem.o*
../gsc/gsc -:~~bin=../bin,~~lib=../lib,~~include=../include -f -i test10.scm
------------ TEST 11 (run unit tests)
make ut
make[2]: Entering directory '/gambit-4.9.4/tests'
../gsi/gsi -:tl,~~bin=../bin,~~lib=../lib,~~include=../include -f ./run-unit-tests.scm
[285|  0] 100% ████████████████ 69.4s
PASSED ALL 285 UNIT TESTS
make[2]: Leaving directory '/gambit-4.9.4/tests'
============ ALL TESTS SUCCESSFUL
rm -f mem.c mem_.c mem.o mem.o1 mem_.o mem \
  mix.c mix_.c mix.o mix_.o mix \
  server.c server_.c server.o server_.o client.o \
  client so_locations *.out tmp*
make[1]: Leaving directory '/gambit-4.9.4/tests'
```

It will be tested on real hardware soon: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/41922/pipelines