### PR TITLE
warn user when symbol is undefined

### DIFF
--- a/gsc/_env.scm
+++ b/gsc/_env.scm
@@ -59,22 +59,7 @@
 (define make-global-environment #f)
 (set! make-global-environment
   (lambda ()
-    (vector
-     ;; cell containing variables in this frame and an association between each
-     ;; symbol and it's namespace
-     (cons '() #f)
-     ;; macro definitions
-     '()
-     ;; declarations
-     '()
-     ;; namespace
-     '()
-     ;; parent env
-     #f
-     ;; externals. This field is only used in the global environment, but many
-     ;; functional setter functions assume `make-global-environment` and
-     ;; `env-frame` return the same shape of object.
-     (make-table))))
+    (env-frame #f '())))
 
 (define (env-frame env vars)
   (vector

--- a/gsc/_env.scm
+++ b/gsc/_env.scm
@@ -58,7 +58,23 @@
 
 (define make-global-environment #f)
 (set! make-global-environment
-      (lambda () (env-frame #f '())))
+  (lambda ()
+    (vector
+     ;; cell containing variables in this frame and an association between each
+     ;; symbol and it's namespace
+     (cons '() #f)
+     ;; macro definitions
+     '()
+     ;; declarations
+     '()
+     ;; namespace
+     '()
+     ;; parent env
+     #f
+     ;; externals. This field is only used in the global environment, but many
+     ;; functional setter functions assume `make-global-environment` and
+     ;; `env-frame` return the same shape of object.
+     (make-table))))
 
 (define (env-frame env vars)
   (vector
@@ -76,7 +92,7 @@
    ;; externals. This field is only used in the global environment, but many
    ;; functional setter functions assume `make-global-environment` and
    ;; `env-frame` return the same shape of object.
-   (make-table)))
+   (if env (env-externals-ref env) (make-table))))
 
 (define (env-new-var! env name source)
   (let* ((glob (not (env-parent-ref env)))
@@ -149,7 +165,7 @@
                (space (car x))
                (aliases (cdr x)))
           (if (null? aliases)
-              (cons (make-full-name space name) #f)
+              (cons (make-full-name space name) x)
               (let ((a (assq name aliases)))
                 (if a
                     (cons (make-full-name space (cdr a))

--- a/gsc/_front.scm
+++ b/gsc/_front.scm
@@ -248,10 +248,6 @@
               (env (vector-ref v2 1))
               (c-intf (vector-ref v2 2))
               (parsed-program (normalize-program lst)))
-         (define (lset-minus a b)
-           (keep (lambda (x)
-                     (not (member x b)))
-                   a))
 
          (let* ((externals (env-externals-ref env))
                 (name->ref-alist (map (lambda (var) (cons
@@ -267,10 +263,10 @@
                 ;; clause.
                 (univ-names (keep (lambda (name)
                                       (let ((ns (table-ref externals name #f)))
-                                        (or (not ns)
-                                            (null? (cdr ns)))))
+                                        (and ns
+                                             (null? (cdr ns)))))
                                     used-names))
-                (undefined-names (lset-minus univ-names defined-names)))
+                (undefined-names (lset-difference univ-names defined-names)))
 
            (define (map-filter f lst)
              (if (pair? lst)

--- a/gsc/_front.scm
+++ b/gsc/_front.scm
@@ -269,7 +269,8 @@
                                       (let ((ns (table-ref externals name #f)))
                                         (or (not ns)
                                             (null? (cdr ns)))))
-                                    used-names)))
+                                    used-names))
+                (undefined-names (lset-minus univ-names defined-names)))
 
            (define (map-filter f lst)
              (if (pair? lst)
@@ -279,25 +280,38 @@
                        (map-filter f (cdr lst))))
                  lst))
 
-           (for-each
-            (lambda (name)
-
-              (let ((name-and-refs (assoc name name->ref-alist)))
-                (if name-and-refs
-                    (let ((refs (map-filter (lambda (x) (and (pair? x)
-                                                        (car x)))
-                                            (vector->list (cdr name-and-refs)))))
-                      (for-each
-                       (lambda (ref)
-                         (compiler-user-warning
-                          (source-locat (node-source ref))
-                          (string-append
-                           "\""
-                           (symbol->string (car name-and-refs))
-                           "\""
-                           " is not defined")))
-                       refs)))))
-            (lset-minus univ-names defined-names)))
+           (let ((namespace-to-undefined-names
+                  (let ((table (make-table)))
+                    (let lp ((undefined-names undefined-names))
+                      (if (pair? undefined-names)
+                          (let* ((name (car undefined-names))
+                                 (its-namespace (table-ref externals name #f)))
+                            (table-set! table
+                                        its-namespace
+                                        (cons name (table-ref table its-namespace '())))
+                            (lp (cdr undefined-names)))
+                          table)))))
+             (for-each
+              (lambda (ns-and-names)
+                (for-each
+                 (lambda (name)
+                   (let* ((name-and-refs (assoc name name->ref-alist)))
+                     (if name-and-refs
+                         (let ((refs (map-filter (lambda (x) (and (pair? x)
+                                                             (car x)))
+                                                 (vector->list (cdr name-and-refs)))))
+                           (for-each
+                            (lambda (ref)
+                              (compiler-user-warning
+                               (source-locat (node-source ref))
+                               (string-append
+                                "\""
+                                (symbol->string name)
+                                "\""
+                                " is not defined")))
+                            refs)))))
+                 (cdr ns-and-names)))
+              (table->list namespace-to-undefined-names))))
 
          (inner parsed-program
                 env

--- a/gsc/_utils.scm
+++ b/gsc/_utils.scm
@@ -1001,5 +1001,10 @@
 
   (list->string (map byte->char (uint32vect->bytes uint32vect))))
 
+(define (lset-difference a b)
+  (keep (lambda (x)
+          (not (member x b)))
+        a))
+
 ;;;============================================================================
 )


### PR DESCRIPTION
This commit adds in `_env.scm` a new field to the env to accumulates a binding between each symbol and it's origin namespace.
It also adds a phase to warn the user about variables that are probably undefined: those used, but not "declared" in a `(##namespace ("ns#" <var>))` form.