### PR TITLE
init-modules: update the initialization flag for each supplied module

### DIFF
--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -5581,13 +5581,27 @@ end-of-code
 
     (define (init module)
       (let* ((s (macro-module-stage module))
-             (module-descr (macro-module-module-descr module)))
+             (module-descr (macro-module-module-descr module))
+             (supplied (macro-module-descr-supply-modules (macro-module-module-descr module))))
+
         (cond ((##fx>= s stage))
               ((##fx= s 0)
-               (macro-module-stage-set! module 1)
+
+               (for-each
+                (lambda (sup-mod-name)
+                  (let ((sup-mod (##lookup-registered-module sup-mod-name)))
+                    (macro-module-stage-set! sup-mod 1)))
+                (vector->list supplied))
+
                (##init-mod module-descr))
               ((##fx= s 1)
-               (macro-module-stage-set! module 2)
+
+               (for-each
+                (lambda (sup-mod-name)
+                  (let ((sup-mod (##lookup-registered-module sup-mod-name)))
+                    (macro-module-stage-set! sup-mod 2)))
+                (vector->list supplied))
+
                ((macro-module-descr-thunk module-descr))))))
 
     (if (##fx<= stage level)


### PR DESCRIPTION
Two modules that are declared in the same file don't activate each other. This leads to double loading in the scenario in which the two modules are loaded.

```scheme
;; b.scm
(##supply-module a)
(display "in a\n")
(##supply-module b)
(display "in b\n")

main.scm
(##demand-module a)
(##demand-module b)
(display "done\n")
```

`gsc/gsc -:= -exe -nopreload b.scm main.scm`
`./main`
```
in a
in b
in a
in b
done
```