### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,5 +13,6 @@
 *.fdd binary
 *.nsi.in binary
 *.windows.in binary
+_*.c linguist-generated
 tests/test*.ok -text
 tests/error.scm -text


### PR DESCRIPTION
Let GitHub know that _*.c are generated by gsc, not source files.

Generated files are excluded from language statistics and their diffs are hidden.

Documentation:
https://github.com/github-linguist/linguist/blob/master/docs/overrides.md

Raised by issue #836.