### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,5 +14,6 @@
 *.nsi.in binary
 *.windows.in binary
 _*.c linguist-generated
+lib/psyntax*.pp linguist-generated
 tests/test*.ok -text
 tests/error.scm -text


### PR DESCRIPTION
GitHub Linguist wrongly classified psyntax*.pp as Pascal source files.