### PR TITLE
Remove target directory on module compilation error

### DIFF
--- a/lib/module-common.mk.in
+++ b/lib/module-common.mk.in
@@ -224,7 +224,12 @@ modules-pre:
 	    fi; \
 	    if test "$$need_to_build_module" = "yes"; then \
 	      echo ">>>> building module $$modref for $$target"; \
-	      @SETDLPATH@ $(rootfromhere)/gsc/gsc@exe@ -:~~bin=$(srcdirpfx)$(rootfromhere)/bin,~~lib=$(srcdirpfx)$(rootfromhere)/lib,~~include=$(srcdirpfx)$(rootfromhere)/include -f -e "(let ((x (##build-module \"$$mod_dir$$main_mod\" (quote $$target) (quote ((module-ref $$modref)(warnings)))))) (if (not x) (begin (println \"*** module failed to build\") (exit 1))))"; \
+	      ret=0; \
+	      @SETDLPATH@ $(rootfromhere)/gsc/gsc@exe@ -:~~bin=$(srcdirpfx)$(rootfromhere)/bin,~~lib=$(srcdirpfx)$(rootfromhere)/lib,~~include=$(srcdirpfx)$(rootfromhere)/include -f -e "(let ((x (##build-module \"$$mod_dir$$main_mod\" (quote $$target) (quote ((module-ref $$modref)(warnings)))))) (if (not x) (begin (println \"*** module failed to build\") (exit 1))))" || ret=$$?; \
+	      if [ $$ret -ne 0 ]; then \
+	        rm -rf "$$build_dir"; \
+	        exit $$ret; \
+	      fi; \
 	    else \
 	      echo ">>>> no need to build module $$modref for $$target"; \
 	    fi; \


### PR DESCRIPTION
Without this modification, the second try to `make -C lib/srfi/some-module modules` after a compilation error proceeds successfully.
