### PR TITLE
Make the "duplicate pattern variable" message more informative

### DIFF
--- a/lib/_syntax-pattern.scm
+++ b/lib/_syntax-pattern.scm
@@ -117,7 +117,7 @@
             (else
              (let ((x (assq sym pattern-vars)))
                (if x
-                   (error "duplicate pattern variable")
+                   (error "duplicate pattern variable: " sym pattern-vars)
                    (let ((index (length pattern-vars)))
                      (cont (vector (syn#pattern-var)) ;; TODO: replace with '#(0) to allow sharing?
                            (cons (cons sym (cons index rank))


### PR DESCRIPTION
Having the `sym` and `pattern-vars` info makes it possible to guess which expression the error concerns.