### PR TITLE
fix argument length mismatch checking in vector-map and vector-for-each

### DIFF
--- a/lib/_std#.scm
+++ b/lib/_std#.scm
@@ -1262,8 +1262,8 @@ end-of-code
                                                  (if (##fx> len-arg max-len)
                                                      (loop (##cdr lst)
                                                            (##cons arg rev-x-y)
+                                                           min-len
                                                            len-arg
-                                                           max-len
                                                            arg-num
                                                            (##fx+ arg-num 1))
                                                      (loop (##cdr lst)
@@ -1360,8 +1360,8 @@ end-of-code
                                                  (if (##fx> len-arg max-len)
                                                      (loop (##cdr lst)
                                                            (##cons arg rev-x-y)
+                                                           min-len
                                                            len-arg
-                                                           max-len
                                                            arg-num
                                                            (##fx+ arg-num 1))
                                                      (loop (##cdr lst)

--- a/tests/unit-tests/07-vector/vector_for_each.scm
+++ b/tests/unit-tests/07-vector/vector_for_each.scm
@@ -103,3 +103,6 @@
 
 (check-tail-exn wrong-number-of-arguments-exception? (lambda () (vector-for-each)))
 (check-tail-exn wrong-number-of-arguments-exception? (lambda () (vector-for-each one)))
+
+(set! ##allow-length-mismatch? #f)
+(check-tail-exn length-mismatch-exception? (lambda () (vector-for-each one '#(1) '#(1 2) '#(1))))

--- a/tests/unit-tests/07-vector/vector_map.scm
+++ b/tests/unit-tests/07-vector/vector_map.scm
@@ -7,7 +7,7 @@
 (define vect2 (vector 11 22))
 
 (define (inc x) (+ x 1))
-(define (add x y) (+ x y))
+(define add +)
 
 (check-equal? (vector-map inc vect0) '#())
 (check-equal? (vector-map inc vect1) '#(12))
@@ -42,3 +42,6 @@
 
 (check-tail-exn wrong-number-of-arguments-exception? (lambda () (vector-map)))
 (check-tail-exn wrong-number-of-arguments-exception? (lambda () (vector-map inc)))
+
+(set! ##allow-length-mismatch? #f)
+(check-tail-exn length-mismatch-exception? (lambda () (vector-map add '#(1) '#(1 2) '#(1))))


### PR DESCRIPTION
This regards https://github.com/gambit/gambit/issues/884

I believe this change fixes the issue. It was due to the loop arguments being updated incorrectly. The current implementation changes `min-len` to `len-arg` and changes `min-len` to `max-len` when `len-arg` exceeds `max-len`. I think rather in this case `max-len` should be updated to `len-arg`, and `min-len` should be left alone, which this PR implements. 

Second, since it was also brought up in issue #884, I'm pretty sure that `max-arg` is updated appropriately since it
represents the index of the argument with the maximum length, and so it is changed only when a new max is found.

The issue also questions the number of args passed to `##raise-length-mismatch-exception`. I think passing the empty list as the first argument is intentional, as this is checked for by `##extract-procedure-and-arguments` in `lib/_kernel.scm`. Since it is `x-y` that is passed as args and not each vector individually, it needs to be concatenated rather than appended to correctly report the error, and the empty list seems to be the indicator to do this. Compare:

```
> (##raise-length-mismatch-exception 3 '() map + '((1) (1 2) (1)))
*** ERROR IN (stdin)@4.1-4.65 -- (Argument 3) Length does not match other arguments
(map '#<procedure #2 +> '(1) '(1 2) '(1))
```
and
```
> (##raise-length-mismatch-exception 3 map + '((1) (1 2) (1)))    
*** ERROR IN (stdin)@5.1-5.61 -- (Argument 3) Length does not match other arguments
(map '#<procedure #2 +> '((1) (1 2) (1)))
```
(the list arguments to the map are wrapped in a list in the second example's error, but joined into the entire expression in the first.)

So the current implementation of the error reporting seems right to me.

I have added corresponding tests. I wasn't sure if there was an established protocol to set variables like `##allow-length-mismatch?` for testing.