### PR TITLE
inline xcons

### DIFF
--- a/gsc/_t-c-2.scm
+++ b/gsc/_t-c-2.scm
@@ -2572,6 +2572,15 @@
     #f ;; flo-result?
     (targ-apply-simp-generator #f #f "CONS")))
 
+(define (targ-apply-xcons)
+  (targ-apply-alloc
+    (lambda (n) targ-pair-space)
+    #t ;; proc-safe?
+    #f ;; side-effects?
+    #f ;; flo-result?
+    (lambda (opnds sn)
+      (cons "CONS" (reverse (map targ-opnd opnds))))))
+
 (define (targ-apply-list)
   (targ-apply-alloc
     (lambda (n) (* n targ-pair-space))
@@ -3502,6 +3511,7 @@
 ;;; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 (targ-op "##cons"             (targ-apply-cons))
+(targ-op "##xcons"            (targ-apply-xcons))
 (targ-op "##set-car!"         (targ-apply-simp-u #f #t 1 "SETCAR"))
 (targ-op "##set-cdr!"         (targ-apply-simp-u #f #t 1 "SETCDR"))
 (targ-op "##car"              (targ-ifjump-apply-u "CAR"))

--- a/gsc/_t-univ-4.scm
+++ b/gsc/_t-univ-4.scm
@@ -1371,6 +1371,11 @@
    (lambda (ctx return arg1 arg2)
      (return (^cons arg1 arg2)))))
 
+(univ-define-prim "##xcons" #t
+  (make-translated-operand-generator
+   (lambda (ctx return arg1 arg2)
+     (return (^cons arg2 arg1)))))
+
 (univ-define-prim "##set-car!" #f
   (make-translated-operand-generator
    (lambda (ctx return arg1 arg2)

--- a/gsc/tests/04-pair/xcons.scm
+++ b/gsc/tests/04-pair/xcons.scm
@@ -1,0 +1,6 @@
+(declare (extended-bindings) (not constant-fold) (not safe))
+
+(define x (##xcons 11 22))
+
+(println (##car x))
+(println (##cdr x))


### PR DESCRIPTION
I'm trying my hand at #759 

I think it "works" in the sense that if I look at the gvm IR produced by compiling `(xcons 1 2)` I now get:

```
#1 fs=0 entry-point nparams=0 ()            [] r0=#ret
  if (##eq? global[xcons] '#<primitive xcons>) jump fs=0 #4 else #2 [] r0=#ret
#2 fs=0   <- #1                             [] r0=#ret
  r2 = '2                                   [] r0=#ret r2=#
  r1 = '1                                   [] r0=#ret r1=# r2=#
  jump/poll fs=0 #3                         [] r0=#ret r1=# r2=#
#3 fs=0   <- #2                             [] r0=#ret r1=# r2=#
  jump/safe fs=0 global[xcons] nargs=2      [] r0=#ret r1=# r2=#
#4 fs=0   <- #1                             [] r0=#ret
  r1 = (##xcons '1 '2)                      [] r0=#ret r1=#
  jump fs=0 r0                              [] r1=#
```

Is this it and did I take the right approach? Was it right to implement in terms of `^cons` and `CONS`, the latter referring to the macro in `include/gambit.h.in`? I also tried adding an XCONS macro in the header and using this instead (i.e. `targ-apply-xcons` would have `(targ-apply-simp-generator #f #f "XCONS")`) , and making an `^xcons` macro, but it seemed like overkill compared to implementing in terms of cons. Also, is there a way to test these things, or what else do I need to do to fill the PR out?

Once I saw what to do I agree it that it's "trivial" but it was definitely found triviality to me in the sense that it was quite the interesting tour, so I'd appreciate any comments on how this is actually going together because I pretty much just implemented by following what was done for cons. Is it right to frame what I've done as 'installing xcons as a primitive'? how does this get picked up, is it by the `define-prim&proc` machinery somehow? and what is the difference between adding the operator to the C backend in `_t-c-2.scm` and defining the primitive in `_t-univ-4.scm`, how do they relate?

Cheers