### PR TITLE
inline xcons

### DIFF
--- a/gsc/_t-c-2.scm
+++ b/gsc/_t-c-2.scm
@@ -2578,8 +2578,7 @@
     #t ;; proc-safe?
     #f ;; side-effects?
     #f ;; flo-result?
-    (lambda (opnds sn)
-      (cons "CONS" (reverse (map targ-opnd opnds))))))
+    (targ-apply-simp-generator #f #f "XCONS")))
 
 (define (targ-apply-list)
   (targ-apply-alloc

--- a/gsc/_t-c-2.scm
+++ b/gsc/_t-c-2.scm
@@ -2572,6 +2572,15 @@
     #f ;; flo-result?
     (targ-apply-simp-generator #f #f "CONS")))
 
+(define (targ-apply-xcons)
+  (targ-apply-alloc
+    (lambda (n) targ-pair-space)
+    #t ;; proc-safe?
+    #f ;; side-effects?
+    #f ;; flo-result?
+    (lambda (opnds sn)
+      (cons "CONS" (reverse (map targ-opnd opnds))))))
+
 (define (targ-apply-list)
   (targ-apply-alloc
     (lambda (n) (* n targ-pair-space))
@@ -3502,6 +3511,7 @@
 ;;; - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 (targ-op "##cons"             (targ-apply-cons))
+(targ-op "##xcons"            (targ-apply-xcons))
 (targ-op "##set-car!"         (targ-apply-simp-u #f #t 1 "SETCAR"))
 (targ-op "##set-cdr!"         (targ-apply-simp-u #f #t 1 "SETCDR"))
 (targ-op "##car"              (targ-ifjump-apply-u "CAR"))

--- a/gsc/_t-univ-4.scm
+++ b/gsc/_t-univ-4.scm
@@ -1371,6 +1371,11 @@
    (lambda (ctx return arg1 arg2)
      (return (^cons arg1 arg2)))))
 
+(univ-define-prim "##xcons" #t
+  (make-translated-operand-generator
+   (lambda (ctx return arg1 arg2)
+     (return (^cons arg2 arg1)))))
+
 (univ-define-prim "##set-car!" #f
   (make-translated-operand-generator
    (lambda (ctx return arg1 arg2)

--- a/gsc/tests/04-pair/xcons.scm
+++ b/gsc/tests/04-pair/xcons.scm
@@ -1,0 +1,6 @@
+(declare (extended-bindings) (not constant-fold) (not safe))
+
+(define x (##xcons 11 22))
+
+(println (##car x))
+(println (##cdr x))

--- a/include/gambit.h.in
+++ b/include/gambit.h.in
@@ -3953,6 +3953,7 @@ ___ADD_PAIR_ELEM(___PAIR_CDR,y); \
 ___END_ALLOC_PAIR();}
 
 #define ___CONS(x,y)(___ALLOC_PAIR_EXPR(x,y),___GET_PAIR())
+#define ___XCONS(x,y)(___ALLOC_PAIR_EXPR(y,x),___GET_PAIR())
 
 #define ___SETCAR(obj,car)___CAR_FIELD(obj)=car;
 #define ___SETCDR(obj,cdr)___CDR_FIELD(obj)=cdr;


### PR DESCRIPTION
Issue #759, this PR is a cleaned up version of #893 (the commit history of that PR is a faff)

Code generation for `xcons` is added to the C and universal backends.

I did nothing regarding the machine code backends, partially because I could not figure out how to build/test the x86-64 backend and partially because of this message from @feeley in the gambit chatroom after I asked about the native backends:

> Yes indeed the native backends are special in that they don’t need to implement any primitives (except the really basic `##not` and `##identity` that are required for the GVM `if` instruction). Of course, to a lesser extent, the other backends can fallback on the primitive procedures (e.g. `xcons`) instead of inlining those primitives.