### PR TITLE
draft implementation of prefix directory for intermediate compilation results

### DIFF
--- a/gsc/_gsclib.scm
+++ b/gsc/_gsclib.scm
@@ -85,6 +85,32 @@
                                          opts
                                          out)))))))
 
+(define ##compile-output-dir
+  ;; fixme: path separator is platform specific (should be a library constant?)
+  (let* ((path-separator "/")
+         (path-reader (lambda (p) (##read-all p (lambda (p) (##read-line p #\/)))))
+         ;; fixme: this parameter probably should come from `options`
+         ;; we could benefit from having this as a cli argument
+         (output-prefix (##get-environment-variable "GAMBIT_OUTPUT_PREFIX"))
+         (output-prefix (and output-prefix (##path-normalize output-prefix))))
+    (lambda (path)
+      (let* ((output-path (if (and output-prefix (##string-prefix? path-separator path))
+                            (##string-append "." path) path))
+             (output-path (if (and output-prefix (##not (##string-prefix? output-prefix path)))
+                            (##path-expand output-path output-prefix) path)))
+	    (when output-prefix
+          ;; fixme: no platform independent path-split procedure in Gambit? huh
+          ;; or better, do as Gerbil does - create-directory* with `mkdir -p` semantics
+          (let loop ((acc "")
+				     (next (##call-with-input-string (##path-directory output-path) path-reader)))
+		    (when (and (##> (##string-length acc) 0)
+                       (##not (##file-exists? acc)))
+		      (##create-directory acc))
+	        (when (##pair? next)
+		      (loop (##string-append acc path-separator (car next))
+                    (cdr next)))))
+        output-path))))
+
 (define (##compile-file-to-target filename-or-source options output)
   (let* ((options
           (##compile-options-normalize options))
@@ -104,7 +130,7 @@
                        (##source-path filename-or-source)
                        filename-or-source))
                   (expanded-output
-                   (##path-normalize output))
+                   (##compile-output-dir (##path-normalize output)))
                   (output-directory?
                    (##not (##equal? expanded-output
                                     (##path-strip-trailing-directory-separator
@@ -319,7 +345,7 @@
                  (##path-strip-extension filename)
                  (##caar (c#target-file-extensions target)))))
            (expanded-output
-            (##path-normalize output))
+            (##compile-output-dir (##path-normalize output)))
            (output-directory?
             (##not (##equal? expanded-output
                              (##path-strip-trailing-directory-separator


### PR DESCRIPTION
Some systems or package managers (like Nix and Guix) use read-only filesystem to store dependencies. Gambit writes intermediate compilation objects into the directory of the input file, just changing the extension.

This pull request adds `GAMBIT_OUTPUT_PREFIX` environment variable which change intermediate compilation objects location. Motivated by the error I've got while using Gerbil to write an application and packaging it's dependencies using Nix package manager:

```
$ gxc -static -exe -o app app.ss
/nix/store/i2fr4hsl5bs704bp8kihxdxbnvcsm3h3-gerbil-cli/gerbil/lib/static/cli__cli.scm:
*** ERROR IN c#targ-start-dump -- Read-only file system
(open-output-file "/nix/store/i2fr4hsl5bs704bp8kihxdxbnvcsm3h3-gerbil-cli/gerbil/lib/static/cli__cli.c")
#f*** ERROR IN gxc#compile-executable-module/separate --
*** ERROR IN ?
--- Syntax Error at (compile-exe app.ss): Compilation error; process exit with nonzero status
... form:   ("/nix/store/58g7klswv88zp6d3kmdzyk67rf3x5035-gerbil-gerbil-unstable-2024-05-11/gerbil/v0.18.1/bin/gsc"
             "-link"
             "/nix/store/58g7klswv88zp6d3kmdzyk67rf3x5035-gerbil-gerbil-unstable-2024-05-11/gerbil/v0.18.1/lib/static/gerbil__runtime__gambit.c"
             ...
```

Problem is Gambit try to write intermediate compilation objects onto a read-only filesystem (`/nix/store/...`).

Here is a simple demonstration of what effect this patch has. Let's say we have some Scheme file, want to generate C code from it:

```console
 ~/tmp  λ  cat test.scm
(display "hello")
```

Before:

```console
 ~/tmp  λ  gsc -c test.scm
 ~/tmp  λ  ls -la
.rw-r--r-- 3.4k user 18 Jul 18:34 test.c
.rw-r--r--   18 user 18 Jul 18:30 test.scm
```

After:

```console
 ~/tmp  λ  GAMBIT_OUTPUT_PREFIX=prefix gsc -c test.scm
 ~/tmp  λ  tree prefix/
prefix/
└── home
    └── user
        └── tmp
            └── test.c

4 directories, 1 file
 ~/tmp  λ  ls -la
drwxr-xr-x  - user 18 Jul 18:33 prefix
.rw-r--r-- 18 user 18 Jul 18:30 test.scm
```

Key questions:

- what do community think about this feature?
- what may be improved? (probably we may want a CLI flag for this)

If you are interested:

- running `GAMBIT_OUTPUT_PREFIX=prefix gsc -obj test.scm read-only-media/some-other-file.scm` is still not working, not sure why, probably I need a help with this