### PR TITLE
##os-executable-path on OpenBSD

### DIFF
--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -3067,16 +3067,19 @@
 (define-prim (executable-path)
   (##executable-path))
 
-(define-prim (##process-mnemonic-identifier)
-  (let ((path (if (##pair? ##processed-command-line)
-                  (##car ##processed-command-line)
-                  (let ((exec-path (##os-executable-path)))
-                    (if (##string? exec-path)
-                        exec-path
-                        #f)))))
-    (if path
-        (##path-strip-extension (##path-strip-directory path))
-        (##string-append "process" (##number->string (##os-getpid))))))
+(define-primitive (##process-mnemonic-identifier)
+  (let* ((pcl ##processed-command-line)
+	 (path (if (##pair? pcl)
+		   (##car pcl)
+		   (let ((exec-path (##os-executable-path)))
+		     (if (##string? exec-path)
+			 exec-path
+			 #f)))))
+    (##string-append (if path
+			 (##path-strip-extension (##path-strip-directory path))
+			 "process")
+		     "-"
+		     (##number->string (##os-getpid)))))
 
 ;;;----------------------------------------------------------------------------
 
@@ -3109,7 +3112,7 @@
            (let* ((prefix
                    (or path
                        (##path-expand
-                        (##string-append (##process-mnemonic-identifier) "-temp")
+                        (##process-mnemonic-identifier)
                         (##os-path-tempdir))))
                   (pid
                    (##os-getpid))

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -3067,7 +3067,7 @@
 (define-prim (executable-path)
   (##executable-path))
 
-(define-primitive (##process-mnemonic-identifier)
+(define-primitive (process-mnemonic-identifier)
   (let* ((pcl ##processed-command-line)
 	 (path (if (##pair? pcl)
 		   (##car pcl)

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -3067,6 +3067,17 @@
 (define-prim (executable-path)
   (##executable-path))
 
+(define-prim (##process-mnemonic-identifier)
+  (let ((path (if (##pair? ##processed-command-line)
+                  (##car ##processed-command-line)
+                  (let ((exec-path (##os-executable-path)))
+                    (if (##string? exec-path)
+                        exec-path
+                        #f)))))
+    (if path
+        (##path-strip-extension (##path-strip-directory path))
+        (##string-append "process" (##number->string (##os-getpid))))))
+
 ;;;----------------------------------------------------------------------------
 
 ;;; Filesystem operations.
@@ -3098,7 +3109,7 @@
            (let* ((prefix
                    (or path
                        (##path-expand
-                        "gsx-temp"
+                        (##string-append (##process-mnemonic-identifier) "-temp")
                         (##os-path-tempdir))))
                   (pid
                    (##os-getpid))

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -2700,7 +2700,11 @@
                        (expand relpath
                                expanded-dir)))
                     ((##string=? instdir-name "execdir")
-                     (expand-in-instdir relpath "bin"))
+                     (let ((exec-path (##os-executable-path)))
+                       (if (##fixnum? exec-path)
+                           (err exec-path)
+                           (expand relpath
+                                   (##path-directory exec-path)))))
                     (else
                      (let ((dir (##os-path-gambitdir)))
                        (if (##fixnum? dir)

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -3098,9 +3098,7 @@
            (let* ((prefix
                    (or path
                        (##path-expand
-                        (##string-append
-                         (##path-strip-directory (##executable-path))
-                         "-temp")
+                        "gsx-temp"
                         (##os-path-tempdir))))
                   (pid
                    (##os-getpid))

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -2700,11 +2700,7 @@
                        (expand relpath
                                expanded-dir)))
                     ((##string=? instdir-name "execdir")
-                     (let ((exec-path (##os-executable-path)))
-                       (if (##fixnum? exec-path)
-                           (err exec-path)
-                           (expand relpath
-                                   (##path-directory exec-path)))))
+                     (expand-in-instdir relpath "bin"))
                     (else
                      (let ((dir (##os-path-gambitdir)))
                        (if (##fixnum? dir)

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -3120,7 +3120,6 @@
                (let* ((resolved-path
                        (##path-resolve
                         (##string-append prefix
-                                         (##number->string pid)
                                          (if (##fx= i 0)
                                              ""
                                              (##number->string i)))))

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -3112,10 +3112,8 @@
            (let* ((prefix
                    (or path
                        (##path-expand
-                        (##process-mnemonic-identifier)
+                        (##string-append (##process-mnemonic-identifier) "-temp")
                         (##os-path-tempdir))))
-                  (pid
-                   (##os-getpid))
                   (permissions
                    (##psettings->permissions psettings #o777)))
              (let loop ((i 0))

--- a/lib/_nonstd.scm
+++ b/lib/_nonstd.scm
@@ -3067,7 +3067,7 @@
 (define-prim (executable-path)
   (##executable-path))
 
-(define-primitive (process-mnemonic-identifier)
+(define-prim (##process-mnemonic-identifier)
   (let* ((pcl ##processed-command-line)
 	 (path (if (##pair? pcl)
 		   (##car pcl)

--- a/lib/os_files.c
+++ b/lib/os_files.c
@@ -1740,7 +1740,7 @@ ___SCMOBJ ___os_executable_path ___PVOID
 
 #endif
 
-#if defined (USE_readlink) && defined (USE_getpid) && !(defined (__OpenBSD__))
+#if defined (USE_readlink) && defined (USE_getpid) && !defined (__OpenBSD__)
 
   {
     pid_t pid = getpid ();

--- a/lib/os_files.c
+++ b/lib/os_files.c
@@ -1740,7 +1740,7 @@ ___SCMOBJ ___os_executable_path ___PVOID
 
 #endif
 
-#if defined (USE_readlink) && defined (USE_getpid)
+#if defined (USE_readlink) && defined (USE_getpid) && !(defined (__OpenBSD__))
 
   {
     pid_t pid = getpid ();


### PR DESCRIPTION
Hi,

I recently spent some time looking into a test failure and related on quirks on OpenBSD 7.5 and wanted to share (some of) my fixes.

It looks like the behavior I noticed stems from the fact that OpenBSD does not implement a /proc filesystem, but there's an assumption to the contrary in os_files.c.  The first commit directly addresses this by adding a check for `__OpenBSD__` to the relevant ifdef.  It results in more accurate "unimplemented" error messages.

The second commit removes ##create-temporary-directory's dependency on ##executable-path (and thus on ##os-executable-path).  The replaced code is currently used to generate default paths and would usually evaluate to either "gsc-temp" or "gsi-temp"; the replacement is just a hard-coded "gsx-temp".

I've also been using another patch that replaces the application of `(##os-executable-path)` in the definition of ##default-path-expand with `(##string-append (##os-path-gambitdir) "/bin/gambit")`. In most cases, it makes path expansion work as it should on OpenBSD, but for now I'm not including it in this PR; it assumes "execdir" ends with "/bin" and could therefore introduce errors under certain installation configurations.

Please do share any feedback/suggestions, especially re: fixing path expansion.