### PR TITLE
Don't automatically include $PWD/.gambini

### DIFF
--- a/doc/gambit.txi
+++ b/doc/gambit.txi
@@ -499,11 +499,11 @@ An error is not signaled when the file does not exist.  Interpreter
 extensions and patches that are meant to apply to all users and all
 modes should go in that file.
 
-Extensions which are meant to apply to a single user or to a specific
-working directory are best placed in the @dfn{initialization file},
+Extensions which are meant to apply to a single user
+are best placed in the @dfn{initialization file},
 which is a file containing Scheme code.  In all modes, the interpreter
 first tries to locate the initialization file by searching the
-following locations: @file{.gambini} and @file{~/.gambini} (with no
+following locations: @file{~/.gambini} (with no
 extension, a @samp{.sld} extension, a @samp{.scm} extension, and a
 @samp{.six} extension in that order).  The first file that is found is
 examined as though the expression @code{(include

--- a/doc/gambit.txi
+++ b/doc/gambit.txi
@@ -499,18 +499,17 @@ An error is not signaled when the file does not exist.  Interpreter
 extensions and patches that are meant to apply to all users and all
 modes should go in that file.
 
-Extensions which are meant to apply to a single user
-are best placed in the @dfn{initialization file},
-which is a file containing Scheme code.  In all modes, the interpreter
-first tries to locate the initialization file by searching the
-following locations: @file{~/.gambini} (with no
-extension, a @samp{.sld} extension, a @samp{.scm} extension, and a
-@samp{.six} extension in that order).  The first file that is found is
-examined as though the expression @code{(include
-@var{initialization-file})} had been entered at the read-eval-print
-loop where @var{initialization-file} is the file that was found.  Note
-that by using an @code{include} the macros defined in the
-initialization file will be visible from the read-eval-print loop
+Extensions which are meant to apply to a single user are best placed
+in the @dfn{initialization file}, which is a file containing Scheme
+code.  In all modes, the interpreter first tries to locate the
+initialization file by searching the following locations:
+@file{~/.gambini} (with no extension, a @samp{.sld} extension, a
+@samp{.scm} extension, and a @samp{.six} extension in that order).
+The first file that is found is examined as though the expression
+@code{(include @var{initialization-file})} had been entered at the
+read-eval-print loop where @var{initialization-file} is the file that
+was found.  Note that by using an @code{include} the macros defined in
+the initialization file will be visible from the read-eval-print loop
 (this would not have been the case if @code{load} had been used).  The
 initialization file is not searched for or examined when the @samp{-f}
 option is specified.

--- a/gsi/main.scm
+++ b/gsi/main.scm
@@ -163,8 +163,7 @@ usage-end
                #f
                #f)))
 
-    (or (try (macro-initialization-file))
-        (try (in-homedir (macro-initialization-file)))))
+    (try (in-homedir (macro-initialization-file))))
 
   (define (read-source-from-string str name)
     (let ((port


### PR DESCRIPTION
While going over the manual today, I noticed a feature I had previously overlooked in §2.4:
>  In all modes, the interpreter first tries to locate the initialization file by searching the following locations: ‘.gambini’ and ‘~/.gambini’...The first file that is found is examined as though the expression (include initialization-file) had been entered at the read-eval-print loop where initialization-file is the file that was found.

This reminded me of a [a recent issue related to Fedora's Lua package](https://bugzilla.redhat.com/show_bug.cgi?id=2177239).  The situation described there is similar to Gambit's present behavior: a user might unknowingly execute code by running gsi in a certain directory.

Here's a Gambit-specific example of how this works:
```
$ cd $(mktemp -d)
$ echo '(create-directory "could-be-worse")' >.gambini
$ ls
$ gsi -e '(pp (features))'
```
The user, who just wanted to see a list of supported features, will have silently created a new directory.  Could be worse.

For greater effect, you might mentally replace that echo command with `tar -xzf nefarious.tgz` or something similar.  Also note that because ".gambini" begins with a period, it's not included in the default `ls` output.

In the Lua bug I shared earlier, no patch was applied because it could break things for users who depend on this behavior.  Which is a legitimate objection that may also apply to Gambit. _My_ opinion, however, is that the feature is at best annoying (I'd rather not have a dotfile in my working directory inhibit the inclusion of my customizations in `~/.gambini`) and at worst...well, you know.

Patching out this behavior looks trivial -- unless I'm missing something, this PR is all it would take.