### PR TITLE
Improve unit test behavior for "Unimplemented operation" os-exception

### DIFF
--- a/tests/unit-tests/#.scm
+++ b/tests/unit-tests/#.scm
@@ -202,12 +202,16 @@
 (##define-syntax check-exn        (lambda (src) (##expand-check src)))
 (##define-syntax check-tail-exn   (lambda (src) (##expand-check src)))
 
+(define (os-unimplemented-exception-string e)
+  (and (os-exception? e)
+       (let ((err-code (##os-err-code->string (os-exception-code e))))
+         (and (string=? err-code "Unimplemented operation")
+              err-code))))
+
 (define (exit0-when-unimplemented-operation-os-exception thunk)
   (with-exception-catcher
    (lambda (e)
-     (if (and (os-exception? e)
-              (equal? (##os-err-code->string (os-exception-code e))
-                      "Unimplemented operation"))
+     (if (os-unimplemented-exception-string e)
          (exit 0)
          (raise e)))
    thunk))

--- a/tests/unit-tests/#.scm
+++ b/tests/unit-tests/#.scm
@@ -204,9 +204,9 @@
 
 (define (os-unimplemented-exception-string e)
   (and (os-exception? e)
-       (let ((err-code (##os-err-code->string (os-exception-code e))))
-         (and (string=? err-code "Unimplemented operation")
-              err-code))))
+       (let ((err-string (##os-err-code->string (os-exception-code e))))
+         (and (string=? err-string "Unimplemented operation")
+              err-string))))
 
 (define (exit0-when-unimplemented-operation-os-exception thunk)
   (with-exception-catcher

--- a/tests/unit-tests/13-modules/#.scm
+++ b/tests/unit-tests/13-modules/#.scm
@@ -19,7 +19,7 @@
 
 (define (capture-behavior thunk)
   (with-exception-catcher
-   (lambda (e) e)
+   (lambda (e) (or (os-unimplemented-exception-string e) e))
    thunk))
 
 (define (compare-behavior namespaces calls . behaviors)

--- a/tests/unit-tests/13-modules/prim_filesystem.scm
+++ b/tests/unit-tests/13-modules/prim_filesystem.scm
@@ -7,6 +7,7 @@
           (##string-ref cd (##fx- (##string-length cd) 1))))
     (##char=? #\\ directory-separator)))
 
+(let ((capture-behavior exit0-when-unimplemented-operation-os-exception))
 (check-same-behavior ("" "##" "~~lib/gambit/prim/filesystem#.scm")
 
 ;; R7RS
@@ -94,4 +95,4 @@
 (let ((x "test_file.txt")) (write-file-string-list x '("a" "b")) (read-file-string x) (delete-file x))
 (let ((x "test_file.txt")) (write-file-u8vector x (u8vector 33 34 35)) (read-file-string x) (delete-file x))
 
-)
+))

--- a/tests/unit-tests/13-modules/prim_filesystem.scm
+++ b/tests/unit-tests/13-modules/prim_filesystem.scm
@@ -7,7 +7,6 @@
           (##string-ref cd (##fx- (##string-length cd) 1))))
     (##char=? #\\ directory-separator)))
 
-(let ((capture-behavior exit0-when-unimplemented-operation-os-exception))
 (check-same-behavior ("" "##" "~~lib/gambit/prim/filesystem#.scm")
 
 ;; R7RS
@@ -95,4 +94,4 @@
 (let ((x "test_file.txt")) (write-file-string-list x '("a" "b")) (read-file-string x) (delete-file x))
 (let ((x "test_file.txt")) (write-file-u8vector x (u8vector 33 34 35)) (read-file-string x) (delete-file x))
 
-))
+)


### PR DESCRIPTION
This is a follow-up to #918.  It reuses `exit0-when-unimplemented-operation-os-exception` (currently used for network unit tests) for the filesystem unit tests.  It reflects an understanding that "the OS does not implement this operation" an acceptable answer for these tests.

Something I don't love about this is that for a given test in this file, "unimplemented" will be treated as an acceptable answer on platforms where we'd normally expect the tested feature to be implemented (e.g., `executable-path` on Linux).

In the future, it might make sense to adopt elements of either of the following approaches:

1. Distinguish between features that are mandatory on all platforms (e.g., the `file-exists?` procedure, which is explicitly mentioned in R7RS) from features that may or may not be supported on a given platform (e.g., the `executable-path` procedure).

2. Choose `capture-behavior` based on platform.  For example: `capture-behavior` is re-bound only on platforms where certain features are known not to be implemented.

I'm partial to the first approach.  The second would be a move toward Python-style "support tiers", which I don't like and wouldn't really comport with Gambit's philosophy as I understand it.