### PR TITLE
configure.ac: Check for backtrace_symbols_fd in libexecinfo

### DIFF
--- a/configure
+++ b/configure
@@ -8400,6 +8400,63 @@ if test "$ac_res" != no; then :
 fi
 
 
+               { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing backtrace_symbols_fd" >&5
+$as_echo_n "checking for library containing backtrace_symbols_fd... " >&6; }
+if ${ac_cv_search_backtrace_symbols_fd+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char backtrace_symbols_fd ();
+int
+main ()
+{
+return backtrace_symbols_fd ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' execinfo; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_backtrace_symbols_fd=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_backtrace_symbols_fd+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_backtrace_symbols_fd+:} false; then :
+
+else
+  ac_cv_search_backtrace_symbols_fd=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_backtrace_symbols_fd" >&5
+$as_echo "$ac_cv_search_backtrace_symbols_fd" >&6; }
+ac_res=$ac_cv_search_backtrace_symbols_fd
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+fi
+
+
                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
 $as_echo_n "checking for library containing dlopen... " >&6; }
 if ${ac_cv_search_dlopen+:} false; then :

--- a/configure.ac
+++ b/configure.ac
@@ -1819,6 +1819,8 @@ else
 
                AC_SEARCH_LIBS(asin,m)
 
+               AC_SEARCH_LIBS(backtrace_symbols_fd,execinfo)
+
                AC_SEARCH_LIBS(dlopen,dl)
                AC_SEARCH_LIBS(shl_load,dld)
 


### PR DESCRIPTION
I noticed that on my machine, the `configure` script wasn't finding `backtrace_symbols_fd`.  Looks like that's just because it's split out into a separate library on OpenBSD.  This PR should allow this check to succeed on OpenBSD and have no effect on other systems.

I believe I've followed the relevant conventions by including the change to `configure.ac` as well as the resulting code (generated by autoconf 2.69) in `configure`.  But if not, I'll fix it.