### PR TITLE
Improve .info-related infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,10 +44,7 @@ doc/gambit.cp
 doc/gambit.cps
 doc/gambit.fn
 doc/gambit.html
-doc/gambit.info
-doc/gambit.info-1
-doc/gambit.info-2
-doc/gambit.info-3
+doc/gambit.info*
 doc/gambit.ky
 doc/gambit.log
 doc/gambit.pdf

--- a/doc/makefile.in
+++ b/doc/makefile.in
@@ -88,7 +88,7 @@ gambit.info
 DISTFILES = $(RCFILES) $(GENDISTFILES)
 
 INSTFILES_DOC = gambit.pdf gambit*.html gambit.tsv gambit.txt
-INSTFILES_INFO = gambit.info*
+INSTFILES_INFO = gambit.info
 INSTFILES_MAN = gsi.1
 
 all: core
@@ -112,7 +112,7 @@ html: gambit.html gambit.tsv
 txt: gambit.txt
 
 gambit.info: gambit.txi version.txi
-	(cd $(srcdir) && $(MAKEINFO) gambit.txi) || (echo "*** $@ could not be built (perhaps $(MAKEINFO) is not installed?)" > $@)
+	(cd $(srcdir) && $(MAKEINFO) --no-split gambit.txi) || (echo "*** $@ could not be built (perhaps $(MAKEINFO) is not installed?)" > $@)
 
 gambit.ps: gambit.pdf
 	(cd $(srcdir) && $(PDF2PS) gambit.pdf) || (echo "*** $@ could not be built (perhaps $(PDF2PS) is not installed?)" > $@)


### PR DESCRIPTION
Despite being the best, the `.info` format isn't the most popular documentation format.  Which is probably why nobody has complained about the 4.9.5 release tarball's `gambit.info` comprising just a table of contents.  But that's old news, and after this is merged, 4.9.6(?)'s info file should have the same content as the html/txt/pdf versions.

I think the reason for the mishap with 4.9.5 tarball was the presence of the `*` in `INSTFILES_INFO` (meaning all the split info files would be installed after building from source) but not in `GENDISTFILES`.  This commit fixes that discrepancy and also passes `--no-split` to the makeinfo command in `gambit.info`'s recipe.

It also updates `.gitignore` to just use a glob to identify the .info files.  This shouldn't be needed with the `--no-split` option, but using a glob there ensures people don't have to see messages about untracked gambit.info-? files (annoyingly, OpenBSD's neolithic texinfo was generating a `gambit.info-4` file that slipped past `.gitignore`).  The use of `gambit.info*` remains for the "bootclean" targets.

[Relevant email thread from 2013](https://lists.gnu.org/archive/html/texinfo-devel/2013-01/msg00000.html)