### PR TITLE
Correct use of script line to determine program behavior

### DIFF
--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -10570,19 +10570,20 @@
 (define-prim (##readtable-setup-for-standard-level! rt)
   (let ((standard-level (##get-standard-level)))
 
-    (cond ((or (##fx= standard-level 4)  ;; R4RS language
+    (cond ((##fxzero? standard-level) ;; Gambit language, explicit
+           (macro-readtable-case-conversion?-set! rt #f)
+           (macro-readtable-keywords-allowed?-set! rt #t)
+           (macro-readtable-bracket-handler-set! rt '|[...]|)
+           (macro-readtable-brace-handler-set! rt '|{...}|))
+          ((or (##fx= standard-level 4)  ;; R4RS language
                (##fx= standard-level 5)) ;; R5RS language
            (macro-readtable-case-conversion?-set! rt #t)
            (macro-readtable-keywords-allowed?-set! rt #f))
-
           ((or (##fx= standard-level 6)  ;; R6RS language
                (##fx= standard-level 7)) ;; R7RS language
            (macro-readtable-case-conversion?-set! rt #f)
            (macro-readtable-keywords-allowed?-set! rt #f))
-
-          (else ;; Gambit language
-           (macro-readtable-case-conversion?-set! rt #f)
-           (macro-readtable-keywords-allowed?-set! rt #t)
+          (else ;; Gambit language, implicit
            (macro-readtable-bracket-handler-set! rt '|[...]|)
            (macro-readtable-brace-handler-set! rt '|{...}|)))))
 

--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -10570,7 +10570,7 @@
 (define-prim (##readtable-setup-for-standard-level! rt)
   (let ((standard-level (##get-standard-level)))
 
-    (cond ((##fxzero? standard-level) ;; Gambit language, explicit
+    (cond ((##fx= standard-level 0) ;; Gambit language, explicit
            (macro-readtable-case-conversion?-set! rt #f)
            (macro-readtable-keywords-allowed?-set! rt #t)
            (macro-readtable-bracket-handler-set! rt '|[...]|)


### PR DESCRIPTION
I noticed I wasn't able to affect Gambit's case sensitivity using the executable name and spent some time looking into why.  Runtime options (e.g., `-:r5rs`) and the `#!fold-case` directive worked as expected.

After a pleasant safari through `_eval.scm` and `_io.scm`, I managed to track the problem back to the point where `##readtable-setup-for-language!` calls `##readtable-setup-for-standard-level!` (importantly, that point is at the end of `##readtable-setup-for-language!`).

The behavior of `##readtable-setup-for-standard-level!` depends on the value of `(##get-standard-level)`, which evaluates to `0` when Gambit mode has been selected explicitly and defaults to `-1`.

`##readtable-setup-for-standard-level!` interpreted these values in the same way.  By distinguishing "explicit" Gambit mode from "implicit" Gambit mode, we get what I believe is the intended behavior: a command-line runtime argument will override behavior specified by the executable name, but in the absence of such an argument the executable name will determine relevant behaviors.


Before:
```
$ cat ex0.scm
#!/usr/local/Gambit/bin/scheme-r5rs
(pp (eq? 'sym 'SYM))
$ ./ex0.scm
#f
$ cat exA.scm
#!/usr/local/Gambit/bin/scheme-r5rs -:r5rs
(pp (eq? 'sym 'SYM))
$ ./exA.scm
#t
```

After:
```
$ cat ex0.scm
#!/usr/local/Gambit/bin/scheme-r5rs
(pp (eq? 'sym 'SYM))
$ ./ex0.scm
#t
$ cat exB.scm
#!/usr/local/Gambit/bin/scheme-r5rs -:r7rs
(pp (eq? 'sym 'SYM))
$ ./exB.scm
#f
```
