### PR TITLE
feat(try): Manage frontend dependencies with npm

### DIFF
--- a/contrib/try/.gitignore
+++ b/contrib/try/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+try/

--- a/contrib/try/index.html
+++ b/contrib/try/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="UI.css">
     <script src="UI.js"></script>
     <script src="VM.min.js"></script>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+    <script src="jquery.min.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   </head>
 

--- a/contrib/try/makefile.in
+++ b/contrib/try/makefile.in
@@ -127,7 +127,10 @@ core-pre:
 
 core-post:
 
-try: browserfs.min.js codemirror UI.css UI.js index.html VM.min.js
+node_modules:
+	npm ci
+
+try: UI.css UI.js index.html VM.min.js node_modules
 	@echo "===== Copying library files"; \
 	INSTALL="`pwd`/$(INSTALL_DATA)"; \
 	DESTDIR="`pwd`/try"; \
@@ -136,8 +139,9 @@ try: browserfs.min.js codemirror UI.css UI.js index.html VM.min.js
 	(cd "$$DESTDIR" && find lib -path "*@js/*.o1" -exec echo "{}.js" ";" -exec mv "{}" "$$DESTDIR/{}.js" ";" -exec touch "$$DESTDIR/{}" ";" -exec gzip -k9 "$$DESTDIR/{}.js" ";")
 	mkdir try/doc
 	cp `$(GSC) -e '(display (path-expand "~~doc"))'`/gambit.html try/doc/.
-	cp -r browserfs.min.js try/.
-	cp -r codemirror try/.
+	cp -r node_modules/browserfs/dist/browserfs.min.js try/.
+	cp -r node_modules/codemirror try/.
+	cp -r node_modules/jquery/dist/jquery.min.js try/.
 	cp UI.css try/.
 	cp UI.js try/.
 	cp index.html try/.
@@ -159,21 +163,10 @@ VM.js: extra.scm VM.scm
 	cp `$(GSC) -e '(display (path-expand "~~lib/_six/six-expand#.scm"))'` .
 	$(GSC) -target js -label-namespace "z" -exe -o VM.js $(PRELUDE_OPT) -nopreload js.scm six-expand.scm extra.scm VM.scm
 
-VM.min.js: VM.js
-	npx google-closure-compiler --language_in=ECMASCRIPT_2020 --language_out=ECMASCRIPT_2020 --js VM.js --js_output_file VM.min.js
+VM.min.js: VM.js node_modules
+	node_modules/.bin/google-closure-compiler --language_in=ECMASCRIPT_2020 --language_out=ECMASCRIPT_2020 --js VM.js --js_output_file VM.min.js
 	sed -i.tmp -e "s/^'use strict';//" VM.min.js
 	gzip -k -9 VM.min.js
-
-browserfs.min.js:
-	wget https://cdnjs.cloudflare.com/ajax/libs/BrowserFS/$(BROWSERFS)/browserfs.min.js
-
-$(CODEMIRROR).zip:
-	wget https://codemirror.net/$(CODEMIRROR).zip
-
-codemirror: $(CODEMIRROR).zip
-	rm -rf -- $(CODEMIRROR)
-	unzip -q $(CODEMIRROR).zip
-	mv $(CODEMIRROR) codemirror
 
 serve: try
 	@echo "===== A local https server with a self signed certificate is"
@@ -229,7 +222,7 @@ mostlyclean-post mostlyclean-post-nonrec:
 clean-pre: mostlyclean-pre
 
 clean-post clean-post-nonrec: mostlyclean-post-nonrec
-	rm -rf js.scm js\#.scm six.js six-expand.scm six-expand\#.scm six-expand.js VM.min.js* try try.tgz codemirror $(CODEMIRROR)
+	rm -rf js.scm js\#.scm six.js six-expand.scm six-expand\#.scm six-expand.js VM.min.js* try try.tgz
 
 distclean-pre: clean-pre
 
@@ -242,7 +235,7 @@ bootclean-post bootclean-post-nonrec: distclean-post-nonrec
 realclean-pre: bootclean-pre
 
 realclean-post realclean-post-nonrec: bootclean-post-nonrec
-	rm -rf makefile $(CODEMIRROR).zip browserfs.min.js
+	rm -rf makefile
 
 rc-setup-pre:
 	$(RC) add $(RCFILES)

--- a/contrib/try/package-lock.json
+++ b/contrib/try/package-lock.json
@@ -1,0 +1,303 @@
+{
+  "name": "try",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "try",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "browserfs": "^2.0.0",
+        "codemirror": "^5.65.19",
+        "jquery": "^3.7.1"
+      },
+      "devDependencies": {
+        "google-closure-compiler": "^20250625.0.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/browserfs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browserfs/-/browserfs-2.0.0.tgz",
+      "integrity": "sha512-3WyiUf04WRZQqJHaPuCNO+1zPb4NOwYXrr4YuMY0pu81R7UoIEmrCiwLoOqyL+uL+CyVfI4M8ugiPjgkPXVzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.5.0",
+        "pako": "^1.0.5"
+      },
+      "bin": {
+        "make_http_index": "dist/scripts/make_http_index.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.19",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.19.tgz",
+      "integrity": "sha512-+aFkvqhaAVr1gferNMuN8vkTSrWIFvzlMV9I2KBLCWS2WpZ2+UAkZjlMZmEuT+gcXTi6RrGQCkWq1/bDtGqhIA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/google-closure-compiler": {
+      "version": "20250625.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20250625.0.0.tgz",
+      "integrity": "sha512-FQ6yKCRYwo4493Rq6lZrxpmWuJGZuuSruCdtArptkoThadzw4TM0YvQJvwRYnQDUpjj6/x7G14l2n/+8G39AIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "5.x",
+        "google-closure-compiler-java": "^20250625.0.0",
+        "minimist": "1.x",
+        "vinyl": "3.x",
+        "vinyl-sourcemaps-apply": "^0.2.0"
+      },
+      "bin": {
+        "google-closure-compiler": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "google-closure-compiler-linux": "^20250625.0.0",
+        "google-closure-compiler-linux-arm64": "^20250625.0.0",
+        "google-closure-compiler-macos": "^20250625.0.0",
+        "google-closure-compiler-windows": "^20250625.0.0"
+      }
+    },
+    "node_modules/google-closure-compiler-java": {
+      "version": "20250625.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20250625.0.0.tgz",
+      "integrity": "sha512-T916Kvb7JYaIiH9spiJXVKeualLV7PO/KXOJzMhLrW4M6etfvr3s2cTqlhUk+BrxvgxqWBWFbMDRUZbVGPnBaw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/google-closure-compiler-linux": {
+      "version": "20250625.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20250625.0.0.tgz",
+      "integrity": "sha512-2cOYLfG7RF49FnGG+yBGlEndE0es8D7+YIGgF8KnGIkxrfiZhOTyQftFx4z48TZ1Be/1JtM2eNXbD2fuR9nJdA==",
+      "cpu": [
+        "x32",
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/google-closure-compiler-linux-arm64": {
+      "version": "20250625.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux-arm64/-/google-closure-compiler-linux-arm64-20250625.0.0.tgz",
+      "integrity": "sha512-2vKY8UpL03CFe+k1qFma/HnUZnTM3V3K5ukxmk/Xwt3D7CTwn/039zA3AjxsGW5vLp4guVyLtqbS711KeGpLNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/google-closure-compiler-macos": {
+      "version": "20250625.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-macos/-/google-closure-compiler-macos-20250625.0.0.tgz",
+      "integrity": "sha512-/S3d5/oKKw2pEu42Bn+fnoKR0cAjlhOQP1IM0D1aDqNS+jMUXo4bV7RSVB+NSVL65XxIVQOqbnkD5Cfoe8lbrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/google-closure-compiler-windows": {
+      "version": "20250625.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20250625.0.0.tgz",
+      "integrity": "sha512-YBNRFTSuWXDJad1pJ1SPjPFpgImrQr7XeW1D9YrPCv1T5cfM8vy01jFkZIDuUha38kHsPvk7kG3rkYYrJpD8+Q==",
+      "cpu": [
+        "x32",
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/replace-ext": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
+      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/vinyl": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.1.tgz",
+      "integrity": "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^2.1.2",
+        "remove-trailing-separator": "^1.1.0",
+        "replace-ext": "^2.0.0",
+        "teex": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "source-map": "^0.5.1"
+      }
+    }
+  }
+}

--- a/contrib/try/package.json
+++ b/contrib/try/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "try",
+  "version": "1.0.0",
+  "description": "This program implements the \"online Gambit Scheme REPL\" web app.  It is a REPL running entirely inside the browser that allows experimentation with Gambit and the DOM.",
+  "main": "UI.js",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "browserfs": "^2.0.0",
+    "codemirror": "^5.65.19",
+    "jquery": "^3.7.1"
+  },
+  "devDependencies": {
+    "google-closure-compiler": "^20250625.0.0"
+  }
+}


### PR DESCRIPTION
This pull request streamlines the dependency management for the try frontend by exclusively using npm. Previously, dependencies were managed using a combination of npx, wget, and unzip. This change consolidates the process, making dependency management cleaner and more consistent.

I have been improving this codebase locally to prepare a demonstration for a research project that requires functionality equivalent to try.scheme.org. This contribution is part of the feedback from that work. Thank you for developing such a wonderful Scheme implementation.