### PR TITLE
feat: Update https-server.py for Python 3 compatibility

### DIFF
--- a/contrib/try/https-server.py
+++ b/contrib/try/https-server.py
@@ -1,15 +1,18 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import os, sys
-import BaseHTTPServer
-import CGIHTTPServer
-import cgitb; cgitb.enable() # enable CGI error reporting
+import http.server
 import ssl
-server = BaseHTTPServer.HTTPServer
-handler = CGIHTTPServer.CGIHTTPRequestHandler
-server_address = ("localhost", 4443)
+#import cgitb; cgitb.enable(display=0, logdir=".") # Deprecated
+
+PORT = 4443
+CERTFILE = "https-server-certificate.pem"
+SERVER_ADDRESS = ("localhost", PORT)
+handler = http.server.CGIHTTPRequestHandler
 handler.cgi_directories = ["/cgi-bin"]
-os.chdir(".")
-srvobj = server(server_address, handler)
-srvobj.socket = ssl.wrap_socket(srvobj.socket, certfile="https-server-certificate.pem", server_side=True)
-handler.have_fork = False # to use ssl, fork must not be used
-srvobj.serve_forever()
+httpd = http.server.HTTPServer(SERVER_ADDRESS, handler)
+context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+context.load_cert_chain(certfile=CERTFILE)
+httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+print(f"Server started successfully.")
+print(f"Serving HTTPS on https://{SERVER_ADDRESS[0]}:{SERVER_ADDRESS[1]}")
+httpd.serve_forever()


### PR DESCRIPTION
Migrate the HTTPS server script from Python 2 to Python 3. This includes:
- Updating the shebang to python3.
- Replacing deprecated modules.
- Modernizing SSL context creation.
