### PR TITLE
Allow strings and u8vectors in open-process's arguments setting.

### DIFF
--- a/doc/gambit.txi
+++ b/doc/gambit.txi
@@ -15864,9 +15864,9 @@ This setting indicates the location of the executable program in the
 filesystem.  There is no default value for this setting.
 
 @item
-@code{arguments:} @var{list-of-strings}
+@code{arguments:} @var{list-of-strings-or-u8vectors}
 
-This setting indicates the string arguments that are passed to the
+This setting indicates the string or u8vector arguments that are passed to the
 program.  The default value of this setting is the empty list (i.e. no
 arguments).
 

--- a/tests/unit-tests/12-os/utf8_process_arguments.scm
+++ b/tests/unit-tests/12-os/utf8_process_arguments.scm
@@ -1,0 +1,9 @@
+(include "../#.scm")
+
+(check-eqv?
+ (call-with-input-process '(path: "echo" arguments: ("♞")) read-char)
+ #\♞)
+
+(check-eqv?
+ (call-with-input-process '(path: "echo" arguments: (#u8(#xE2 #x99 #x9E))) read-char)
+ #\♞)


### PR DESCRIPTION
Hi Marc,

Thanks for answering my question on gitter (duplicating the conversation here for posterity's sake).

```
Negdayen (Negdayen)
Is there a way to open processes that contain Unicode characters in their arguments? Toy example:

$ ./test
*** ERROR IN "test"@3.1-3.48 -- (Argument 1) Can't convert to C char-string
(open-process '(path: "echo" arguments: ("🐰")))

On Unix Gambit's open-process is implemented with execvp which does not specify the
encoding of the strings it receives.  That is because the data is just passed to the
process as a sequence of bytes (char in C) with no specific interpretation.  So one
workaround is to perform the specific encoding you want, presumably UTF8:

Most programs started with open-process probably expect the command line arguments to be
strings encoded with UTF8, but some probably don't, so there needs to be a way to pass raw
bytes when needed. So perhaps the list passed as arguments: should allow both strings
(which will be UTF8 encoded) and u8vectors that are passed as-is. I'll accept PRs for this
feature.
```

Does this meet the requirements?