### PR TITLE
Fix SMP multiple-VM setup global cell access

### DIFF
--- a/lib/setup.c
+++ b/lib/setup.c
@@ -1476,14 +1476,17 @@ int n;)
 
 
 ___HIDDEN ___SCMOBJ make_global
-   ___P((___BOOL collect_undef_glo,
+   ___P((___processor_state ___ps,
+         ___BOOL collect_undef_glo,
          ___UTF_8STRING str,
          int supply,
          ___glo_struct **glo),
-        (collect_undef_glo,
+        (___ps,
+         collect_undef_glo,
          str,
          supply,
          glo)
+___processor_state ___ps;
 ___BOOL collect_undef_glo;
 ___UTF_8STRING str;
 int supply;
@@ -1649,7 +1652,8 @@ ___module_struct *module;)
       while (i-- > 0)
         {
           ___glo_struct *glo = 0;
-          ___SCMOBJ e = make_global (ctx->collect_undef_glo,
+          ___SCMOBJ e = make_global (ctx->ps,
+                                     ctx->collect_undef_glo,
                                      glo_names[i],
                                      i<supcount,
                                      &glo);


### PR DESCRIPTION
## Summary

- pass the current processor state into `make_global` during module setup
- keep `___GLOCELL` usable when `___SINGLE_VM` is not defined, where it expands through `___VMSTATE_FROM_PSTATE(___ps)`
- fixes the SMP + multiple VM build failure in `lib/setup.c` where `setup.o` could not compile because `___ps` was not in scope

This is a candidate SMP bounty fix for the tracker in #760 if maintainers consider this build break eligible. It also appears related to the broader SMP build-breakage tracked in #912.

## Before

Configured on macOS/arm64 with:

```sh
./configure --enable-smp --enable-multiple-vms
make -j4
```

The build failed compiling `lib/setup.c`:

```text
setup.c:1512:21: error: use of undeclared identifier '___ps'
      if (supply && ___GLOCELL(g->val) == ___UNB1)
                    ^
../include/gambit.h:6697:62: note: expanded from macro '___GLOCELL'
#define ___GLOCELL(x)___GLOCELL_IN_VM(___VMSTATE_FROM_PSTATE(___ps),x)
                                                             ^
setup.c:1513:9: error: use of undeclared identifier '___ps'
        ___GLOCELL(g->val) = ___UNB2;
        ^
```

## After

```sh
./configure --enable-smp --enable-multiple-vms
make -j4
./gsi/gsi -v
./gsi/gsi -e '(println (+ 1 2)) (exit)'
git diff --check -- lib/setup.c
```

Results:

- `make -j4` completed successfully after the patch, including built-in modules
- `./gsi/gsi -v` prints `b796969 20260527202657 aarch64-apple-darwin25.3.0 "./configure '--enable-smp' '--enable-multiple-vms'"`
- smoke expression prints `3`
- `git diff --check -- lib/setup.c` passes

## Test note

`make check` currently starts running tests but fails at `tests/mix.scm` with:

```text
*** ERROR IN "mix.scm"@14.31-14.48 -- Unbound variable: ##greatest-fixnum
```

I did not fold that separate SMP test-suite/runtime failure into this PR because this patch is scoped to the missing processor-state build failure in `setup.c`.
