### PR TITLE
Enable multiple-threaded VMs for SMP builds

### DIFF
--- a/configure
+++ b/configure
@@ -6376,6 +6376,12 @@ fi
 
 
 if test "$ENABLE_SMP" = yes; then
+  if test "$ENABLE_MULTIPLE_THREADED_VMS" = no; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: enabling multiple-threaded-vms because --enable-smp was specified" >&5
+$as_echo "$as_me: enabling multiple-threaded-vms because --enable-smp was specified" >&6;}
+    ENABLE_MULTIPLE_THREADED_VMS=yes
+    CONF_SINGLE_MULTIPLE_THREADED_VMS="___MULTIPLE_THREADED_VMS"
+  fi
   RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|enable-smp|)"
 else
   RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|disable-smp|)"

--- a/configure.ac
+++ b/configure.ac
@@ -1295,6 +1295,11 @@ AC_ARG_ENABLE(smp,
               ENABLE_SMP=no)
 
 if test "$ENABLE_SMP" = yes; then
+  if test "$ENABLE_MULTIPLE_THREADED_VMS" = no; then
+    AC_MSG_NOTICE([enabling multiple-threaded-vms because --enable-smp was specified])
+    ENABLE_MULTIPLE_THREADED_VMS=yes
+    CONF_SINGLE_MULTIPLE_THREADED_VMS="___MULTIPLE_THREADED_VMS"
+  fi
   RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|enable-smp|)"
 else
   RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|disable-smp|)"


### PR DESCRIPTION
This addresses one SMP configuration bug tracked by #760.

`./configure --enable-smp` enabled the Scheme-side `enable-smp` feature, but still generated a C runtime configured with `___SINGLE_THREADED_VMS`. That left the resulting `gsi` without the runtime `parallelism` option, and `-:p2` still reported a single VM processor.

This change makes `--enable-smp` also enable `multiple-threaded-vms` during configuration, because the SMP scheduler needs multiple OS threads per VM to actually create multiple processors.

Verification:

- Before the patch, `./configure --enable-smp --prefix=...` generated `include/gambit.h` with `#define ___SINGLE_THREADED_VMS`.
- After the patch, the same configure command generates `#define ___MULTIPLE_THREADED_VMS` and logs `enabling multiple-threaded-vms because --enable-smp was specified`.
- `make core -j2`
- `./gsi/gsi -:p2 -e '(display (list (##get-parallelism-level) (##current-vm-processor-count) (processor? (current-processor)))) (newline)'` prints `(2 2 #t)`.
- `./gsi/gsi -:help` now includes the `parallelism=LEVEL` runtime option.

Note: full `make -j2` got past core/gsi/gsc and then failed during builtin module compilation with `Heap overflow`; `make core -j2` passed and was sufficient for this configure/runtime fix.