### PR TITLE
Fix shell-command wait without captured output

### DIFF
--- a/lib/gambit/process/process.scm
+++ b/lib/gambit/process/process.scm
@@ -125,12 +125,34 @@ c-declare-end
                    (##close-input-port port)
                    (let ((status (##process-status port)))
                      (cont2 (##cons status output))))
-                 (let loop ()
-                   (if (##char? (##read-char port))
-                       (loop)
+                 (let ((capturing? (##not (or (##eq? capture? (macro-absent-obj))
+                                               (##not capture?)))))
+                   (if capturing?
+                       (let loop ()
+                         (if (##char? (##read-char port))
+                             (loop)
+                             (begin
+                               (##close-input-port port)
+                               (cont2 (##process-status port)))))
                        (begin
                          (##close-input-port port)
-                         (cont2 (##process-status port))))))))))
+                         ;; stdout/stderr are not redirected in this case, so
+                         ;; there is no input EOF to wait for on the port.
+                         (let loop ()
+                           (let ((status (##os-device-process-status
+                                          (##port-device port))))
+                             (cond ((##not status)
+                                    (##thread-sleep! 0.01)
+                                    (loop))
+                                   ((##fx< status 0)
+                                    (##raise-os-io-exception
+                                     port
+                                     #f
+                                     status
+                                     process-status
+                                     port))
+                                   (else
+                                    (cont2 status)))))))))))))
    open-process
    (let ((cap (##not (or (##eq? capture? (macro-absent-obj))
                          (##not capture?)))))

--- a/tests/unit-tests/12-os/shell_command.scm
+++ b/tests/unit-tests/12-os/shell_command.scm
@@ -8,6 +8,8 @@
 (check-equal? (shell-command "exit 0" #f) 0)
 (check-equal? (shell-command "exit 1" #f) 256)
 
+(check-equal? (shell-command "echo shell-command-no-capture" #f) 0)
+
 (check-equal? (shell-command "exit 0" #t) '(0 . ""))
 (check-equal? (shell-command "exit 1" #t) '(256 . ""))
 


### PR DESCRIPTION
## Summary

This fixes a `shell-command` hang in SMP builds when subprocess output is not captured.

`##run-subprocess` only redirects stdout/stderr when `capture?` is true or the discard mode is used. For the normal no-capture path, stdout/stderr stay attached to the current process, but the wait path still tried to read from the process port until EOF. In an SMP Windows/w64devkit build this can block after the child process has already exited.

The no-capture path now closes the input side and waits on the process device status directly, while leaving the existing captured-output paths unchanged.

Related to #760.

## Validation

Tested locally on Windows with w64devkit in an SMP + multiple-VM build. On current `master` I had to apply #1003 locally to get that Windows SMP build past setup; this PR does not include that change.

- `./configure --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --enable-smp --enable-multiple-vms`
- `make -j4 core`
- `./gsi/gsi.exe -v`
- `shell-command "echo hello"` prints `hello` and returns `0`
- `shell-command "echo hello > mini-shell-out"` returns `0` and writes `hello`
- captured-output and discard-mode `shell-command` checks still pass
- direct `tests/unit-tests/12-os/shell_command.scm` run, including the new no-capture stdout regression test
- `cd tests && make test1 test2 test3`

Additional validation on WSL Ubuntu 24.04 with GCC 13.3.0:

- `./configure --enable-smp`
- `make core -j4`
- `../gsi/gsi ... -f ./run-unit-tests.scm unit-tests/12-os/shell_command.scm` passed (`PASSED ALL 1 UNIT TESTS`)
- `../gsi/gsi ... -f ./run-unit-tests.scm unit-tests/12-os` passed (`PASSED ALL 6 UNIT TESTS`)

I also compared broader local suite failures against `master` where they were relevant. In this `--enable-smp` setup, `make check` reaches `TEST 4` and fails in `tests/mix.scm` with `Unbound variable: ##greatest-fixnum`; the same failure reproduces on `master` with the same configuration. A broader `make ut` run completed but had unrelated failures in several areas, with representative failures also reproducible on `master`, so I did not treat those as related to the scoped `shell-command` change.

Disclosure: I used Codex (GPT-5.5 xHigh) for a final code review pass after human programming.