### PR TITLE
Add optional GMP-backed bignum multiplication

### DIFF
--- a/configure
+++ b/configure
@@ -1078,6 +1078,7 @@ enable_type_checking
 enable_auto_forcing
 enable_sharp_dot
 enable_bignum
+enable_gmp_bignum
 enable_ratnum
 enable_cpxnum
 enable_s8vector
@@ -1844,6 +1845,8 @@ Optional Features:
   --enable-auto-forcing   automatically force promises (default is NO)
   --enable-sharp-dot      support #.<expression> syntax (default is YES)
   --enable-bignum         support infinite precision integers (default is YES)
+  --enable-gmp-bignum     use LibGMP for large bignum multiplication and
+                          squaring (default is NO)
   --enable-ratnum         support exact rational numbers (default is YES)
   --enable-cpxnum         support complex numbers (default is YES)
   --enable-s8vector       support s8vector type (default is YES)
@@ -6065,6 +6068,96 @@ if test "$ENABLE_BIGNUM" = yes; then
   RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|enable-bignum|)"
 else
   RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|disable-bignum|)"
+fi
+
+# Check whether --enable-gmp-bignum was given.
+if test "${enable_gmp_bignum+set}" = set; then :
+  enableval=$enable_gmp_bignum; ENABLE_GMP_BIGNUM=$enableval
+else
+  ENABLE_GMP_BIGNUM=no
+fi
+
+
+if test "$ENABLE_GMP_BIGNUM" = yes; then
+  if test "$ENABLE_BIGNUM" != yes; then
+    as_fn_error $? "--enable-gmp-bignum requires --enable-bignum" "$LINENO" 5
+  fi
+  for ac_header in gmp.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "gmp.h" "ac_cv_header_gmp_h" "$ac_includes_default"
+if test "x$ac_cv_header_gmp_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GMP_H 1
+_ACEOF
+
+else
+  as_fn_error $? "--enable-gmp-bignum requires gmp.h" "$LINENO" 5
+fi
+
+done
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing __gmpz_mul" >&5
+$as_echo_n "checking for library containing __gmpz_mul... " >&6; }
+if ${ac_cv_search___gmpz_mul+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char __gmpz_mul ();
+int
+main ()
+{
+return __gmpz_mul ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' gmp; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search___gmpz_mul=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search___gmpz_mul+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search___gmpz_mul+:} false; then :
+
+else
+  ac_cv_search___gmpz_mul=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search___gmpz_mul" >&5
+$as_echo "$ac_cv_search___gmpz_mul" >&6; }
+ac_res=$ac_cv_search___gmpz_mul
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else
+  as_fn_error $? "--enable-gmp-bignum requires libgmp" "$LINENO" 5
+fi
+
+  GAMBITLIB_DEFS="$GAMBITLIB_DEFS -D___USE_GMP_BIGNUM"
+  RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|enable-gmp-bignum|)"
+else
+  RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|disable-gmp-bignum|)"
 fi
 
 # Check whether --enable-ratnum was given.

--- a/configure.ac
+++ b/configure.ac
@@ -1028,6 +1028,28 @@ else
   RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|disable-bignum|)"
 fi
 
+AC_ARG_ENABLE(gmp-bignum,
+              AS_HELP_STRING([--enable-gmp-bignum],
+                             [use LibGMP for large bignum multiplication and squaring (default is NO)]),
+              ENABLE_GMP_BIGNUM=$enableval,
+              ENABLE_GMP_BIGNUM=no)
+
+if test "$ENABLE_GMP_BIGNUM" = yes; then
+  if test "$ENABLE_BIGNUM" != yes; then
+    AC_MSG_ERROR([--enable-gmp-bignum requires --enable-bignum])
+  fi
+  AC_CHECK_HEADERS([gmp.h], [], [
+    AC_MSG_ERROR([--enable-gmp-bignum requires gmp.h])
+  ])
+  AC_SEARCH_LIBS([__gmpz_mul], [gmp], [], [
+    AC_MSG_ERROR([--enable-gmp-bignum requires libgmp])
+  ])
+  GAMBITLIB_DEFS="$GAMBITLIB_DEFS -D___USE_GMP_BIGNUM"
+  RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|enable-gmp-bignum|)"
+else
+  RTLIB_COND_EXPAND_FEATURES="$RTLIB_COND_EXPAND_FEATURES(define-cond-expand-feature|disable-gmp-bignum|)"
+fi
+
 AC_ARG_ENABLE(ratnum,
               AS_HELP_STRING([--enable-ratnum],
                              [support exact rational numbers (default is YES)]),

--- a/lib/_num.scm
+++ b/lib/_num.scm
@@ -9,7 +9,13 @@
 
 (macro-case-target
  ((C)
-  (c-declare "#include \"mem.h\"")
+  (c-declare #<<end-of-c-declare
+#include "mem.h"
+#ifdef ___USE_GMP_BIGNUM
+#include <gmp.h>
+#endif
+end-of-c-declare
+)
   (##define-macro (macro-min-bignum-adigits) 1)
   (##define-macro (use-fast-bignum-algorithms) #t))
 
@@ -7609,6 +7615,15 @@ for a discussion of branch cuts.
 (define-prim (##bignum.fft-mul-min-width-set! x)
   (set! ##bignum.fft-mul-min-width x))
 
+(cond-expand
+  (enable-gmp-bignum
+   (define ##bignum.gmp-mul-min-width 20000)
+
+   (define-prim (##bignum.gmp-mul-min-width-set! x)
+     (set! ##bignum.gmp-mul-min-width x)))
+  (else
+   (##begin)))
+
 (define ##bignum.fft-mul-max-width
   (if (##fixnum? -1073741824) ;; #t iff using 64-bit fixnums
       536870912
@@ -8345,6 +8360,235 @@ end-of-code
 )
  (else
   (##begin)))
+
+(cond-expand
+  (enable-gmp-bignum
+   (define-prim (##bignum.gmp-mul x y square?)
+     (##declare (not interrupts-enabled))
+     (macro-case-target
+      ((C)
+       (let ((v
+              (##c-code #<<end-of-code
+
+___SCMOBJ x;
+___SCMOBJ y;
+___SCMOBJ square;
+___SCMOBJ result;
+
+___POP_ARGS3(x,y,square);
+result = ___FAL;
+
+#ifdef ___USE_GMP_BIGNUM
+{
+  mpz_t a;
+  mpz_t b;
+  mpz_t product;
+  mpz_t temp;
+  int product_sign;
+  ___SIZE_TS i;
+  ___SIZE_TS n;
+  size_t count;
+
+#define ___GMP_IMPORT_BIGNUM(rop,obj)                                      \
+  do                                                                       \
+    {                                                                      \
+      ___SCMOBJ ___gmp_obj = (obj);                                        \
+      ___SIZE_TS ___gmp_len = ___INT(___BIGALENGTH(___gmp_obj));           \
+      ___WORD *___gmp_body = ___BODY_AS(___gmp_obj,___tSUBTYPED);          \
+      mpz_import ((rop),                                                   \
+                  ___gmp_len,                                              \
+                  -1,                                                      \
+                  sizeof (___BIGADIGIT),                                   \
+                  0,                                                       \
+                  0,                                                       \
+                  ___gmp_body);                                            \
+      if (___BIGAFETCHSIGNED(___gmp_body, ___gmp_len - 1) < 0)             \
+        {                                                                  \
+          mpz_set_ui (temp, 0);                                            \
+          mpz_setbit (temp,                                                \
+                      ___CAST(mp_bitcnt_t, ___gmp_len) *                  \
+                      ___BIG_ABASE_WIDTH);                                 \
+          mpz_sub ((rop), (rop), temp);                                    \
+        }                                                                  \
+    }                                                                      \
+  while (0)
+
+  mpz_init (a);
+  mpz_init (b);
+  mpz_init (product);
+  mpz_init (temp);
+
+  ___GMP_IMPORT_BIGNUM(a, x);
+
+  if (square != ___FAL)
+    mpz_mul (product, a, a);
+  else
+    {
+      ___GMP_IMPORT_BIGNUM(b, y);
+      mpz_mul (product, a, b);
+    }
+
+  product_sign = mpz_sgn (product);
+
+  if (product_sign < 0)
+    {
+      size_t bits;
+      mp_bitcnt_t sign_bit;
+
+      mpz_abs (temp, product);
+      bits = mpz_sizeinbase (temp, 2);
+      n = (bits + ___BIG_ABASE_WIDTH - 1) / ___BIG_ABASE_WIDTH;
+      if (n == 0)
+        n = 1;
+
+      sign_bit = ___CAST(mp_bitcnt_t, n) * ___BIG_ABASE_WIDTH - 1;
+      mpz_set_ui (b, 0);
+      mpz_setbit (b, sign_bit);
+      if (mpz_cmp (temp, b) > 0)
+        n++;
+    }
+  else
+    {
+      size_t bits = product_sign == 0 ? 1 : mpz_sizeinbase (product, 2);
+      n = (bits + ___BIG_ABASE_WIDTH) / ___BIG_ABASE_WIDTH;
+      if (n == 0)
+        n = 1;
+    }
+
+  if (n > ___CAST(___WORD, ___LMASK>>___LF)/(___BIG_ABASE_WIDTH/8))
+    result = ___FIX(___HEAP_OVERFLOW_ERR);
+  else
+    {
+      ___SIZE_TS words =
+        ___WORDS((n*(___BIG_ABASE_WIDTH/8))) + ___SUBTYPED_BODY;
+
+#if ___BIG_ABASE_WIDTH == 64 && ___WS == 4
+      words++;
+#endif
+
+      ___ps->saved[0] = x;
+      ___ps->saved[1] = y;
+      ___ps->saved[2] = square;
+
+      if (words > ___MSECTION_BIGGEST)
+        {
+          ___FRAME_STORE_RA(___R0)
+          ___W_ALL
+#if ___BIG_ABASE_WIDTH == 32
+          result = ___EXT(___alloc_scmobj) (___ps, ___sBIGNUM, n<<2);
+#else
+          result = ___EXT(___alloc_scmobj) (___ps, ___sBIGNUM, n<<3);
+#endif
+          ___R_ALL
+          ___SET_R0(___FRAME_FETCH_RA)
+          if (!___FIXNUMP(result))
+            ___still_obj_refcount_dec (result);
+        }
+      else
+        {
+          ___BOOL overflow = 0;
+          ___hp += words;
+          if (___hp > ___ps->heap_limit)
+            {
+              ___FRAME_STORE_RA(___R0)
+              ___W_ALL
+              overflow = ___heap_limit (___PSPNC) &&
+                         ___garbage_collect (___PSP 0);
+              ___R_ALL
+              ___SET_R0(___FRAME_FETCH_RA)
+            }
+          else
+            ___hp -= words;
+          if (overflow)
+            result = ___FIX(___HEAP_OVERFLOW_ERR);
+          else
+            {
+#if ___BIG_ABASE_WIDTH == 64 && ___WS == 4
+              result =
+                ___SUBTYPED_FROM_BODY(___CAST(___WORD,
+                                              ___hp+___SUBTYPED_BODY+1)&~7);
+#else
+              result = ___SUBTYPED_FROM_START(___hp);
+#endif
+#if ___BIG_ABASE_WIDTH == 32
+              ___SUBTYPED_HEADER_SET(result,
+                                      ___MAKE_HD_BYTES((n<<2), ___sBIGNUM));
+#else
+              ___SUBTYPED_HEADER_SET(result,
+                                      ___MAKE_HD_BYTES((n<<3), ___sBIGNUM));
+#endif
+              ___hp += words;
+            }
+        }
+
+      x = ___ps->saved[0];
+      y = ___ps->saved[1];
+      square = ___ps->saved[2];
+      ___ps->saved[0] = ___VOID;
+      ___ps->saved[1] = ___VOID;
+      ___ps->saved[2] = ___VOID;
+
+      if (!___FIXNUMP(result))
+        {
+          ___WORD *body = ___BODY_AS(result,___tSUBTYPED);
+
+          for (i=0; i<n; i++)
+            ___BIGASTORE(body, i, 0);
+
+          if (product_sign < 0)
+            {
+              mpz_set_ui (temp, 0);
+              mpz_setbit (temp,
+                          ___CAST(mp_bitcnt_t, n) * ___BIG_ABASE_WIDTH);
+              mpz_add (temp, temp, product);
+              mpz_export (body,
+                          &count,
+                          -1,
+                          sizeof (___BIGADIGIT),
+                          0,
+                          0,
+                          temp);
+            }
+          else
+            {
+              mpz_export (body,
+                          &count,
+                          -1,
+                          sizeof (___BIGADIGIT),
+                          0,
+                          0,
+                          product);
+            }
+        }
+    }
+
+  mpz_clear (temp);
+  mpz_clear (product);
+  mpz_clear (b);
+  mpz_clear (a);
+
+#undef ___GMP_IMPORT_BIGNUM
+}
+#endif
+
+___RESULT = result;
+___PUSH_ARGS3(x,y,square);
+
+end-of-code
+                x
+                y
+                square?)))
+         (cond ((##not v)
+                #f)
+               ((##fixnum? v)
+                (##raise-heap-overflow-exception)
+                (##bignum.gmp-mul x y square?))
+               (else
+                (##bignum.normalize! v)))))
+      (else
+       #f))))
+  (else
+   (##begin)))
 
 (define-prim (##bignum.* x y)
 
@@ -11385,12 +11629,24 @@ end-of-code
     (let ((x-width (##fx* x-length (##bignum.mdigit-width))))
       (cond ((##fx< x-width ##bignum.naive-mul-max-width)
              (naive-mul x x-length y y-length))
-            ((or (##not (use-fast-bignum-algorithms))         ;; Use Karatsuba even for very large integers
-                 (##fx< x-width ##bignum.fft-mul-min-width)   ;; or if x is small enough
-                 (##fx< ##bignum.fft-mul-max-width x-width))  ;; or if x is too large for FFT to work.
-             (karatsuba-mul x y))
             (else
-             (fft-mul x y)))))
+             (cond-expand
+               (enable-gmp-bignum
+                (or (and (##fx>= x-width ##bignum.gmp-mul-min-width)
+                         (##bignum.gmp-mul x y (##eq? x y)))
+                    (cond ((or (##not (use-fast-bignum-algorithms))         ;; Use Karatsuba even for very large integers
+                               (##fx< x-width ##bignum.fft-mul-min-width)   ;; or if x is small enough
+                               (##fx< ##bignum.fft-mul-max-width x-width))  ;; or if x is too large for FFT to work.
+                           (karatsuba-mul x y))
+                          (else
+                           (fft-mul x y)))))
+               (else
+                (cond ((or (##not (use-fast-bignum-algorithms))         ;; Use Karatsuba even for very large integers
+                           (##fx< x-width ##bignum.fft-mul-min-width)   ;; or if x is small enough
+                           (##fx< ##bignum.fft-mul-max-width x-width))  ;; or if x is too large for FFT to work.
+                       (karatsuba-mul x y))
+                      (else
+                       (fft-mul x y)))))))))
 
   ;; Certain decisions must be made for multiplication.
   ;; First, if either bignum is small, just do naive mul to avoid

--- a/tests/unit-tests/03-number/_num.scm
+++ b/tests/unit-tests/03-number/_num.scm
@@ -2,6 +2,44 @@
 
 ;;; These tests come from coverage statistics for part of _num.scm
 
+;;; Large exact integer multiplication and squaring.
+
+(let* ((a (arithmetic-shift 1 21000))
+       (a^2 (arithmetic-shift 1 42000))
+       (a+1 (+ a 1))
+       (1-a (- 1 a)))
+  (check-eqv? (* a+1 a+1)
+              (+ a^2 (arithmetic-shift 1 21001) 1))
+  (check-eqv? (square a+1)
+              (+ a^2 (arithmetic-shift 1 21001) 1))
+  (check-eqv? (* 1-a a+1)
+              (- 1 a^2))
+  (check-eqv? (* (- a) (- a))
+              a^2)
+  (check-eqv? (square (- a))
+              a^2))
+
+(cond-expand
+  (enable-gmp-bignum
+   (let* ((a (+ (arithmetic-shift 1 1600) 1))
+          (b (- (arithmetic-shift 1 1700) 3))
+          (c (- (arithmetic-shift 1 2048) 1))
+          (old-gmp-mul-min-width ##bignum.gmp-mul-min-width))
+     (check-eqv? (##bignum.gmp-mul a b #f)
+                 (* a b))
+     (check-eqv? (##bignum.gmp-mul (- a) b #f)
+                 (- (* a b)))
+     (check-eqv? (##bignum.gmp-mul (- c) c #t)
+                 (* c c))
+     (##bignum.gmp-mul-min-width-set! 1500)
+     (check-eqv? (* a b)
+                 (##bignum.gmp-mul a b #f))
+     (check-eqv? (square (- c))
+                 (##bignum.gmp-mul (- c) c #t))
+     (##bignum.gmp-mul-min-width-set! old-gmp-mul-min-width)))
+  (else
+   #f))
+
 (check-tail-exn type-exception? (lambda () (finite? 'a)))
 (check-eqv? (finite? 0) #t)
 (check-eqv? (finite? 1) #t)


### PR DESCRIPTION
## Summary

This adds an opt-in `--enable-gmp-bignum` configure option that uses LibGMP for large bignum multiplication and squaring.

The default build remains unchanged. When the option is enabled, configure checks for `gmp.h` and `-lgmp`, defines `___USE_GMP_BIGNUM` for the Gambit runtime library build, and large bignum multiplication tries the GMP path before falling back to Gambit's existing algorithms.

The GMP path keeps Gambit's bignum representation unchanged:

- converts Gambit two's-complement bignums into temporary `mpz_t` values
- uses `mpz_mul` for multiplication and squaring
- exports back into a normal movable Gambit bignum
- normalizes the result through the existing bignum normalization path

Related to #761.

## Validation

Validated on Linux/WSL and in Docker `gcc:9.3.0` with LibGMP installed.

- default build: `./configure`, `make -j6 from-scratch`
- default `GAMBITLIB_DEFS` and `_num.o` compile lines do not include `-D___USE_GMP_BIGNUM`
- default targeted number test passed: `../gsi/gsi -:tl,~~bin=../bin,~~lib=../lib,~~include=../include -f ./run-unit-tests.scm unit-tests/03-number/_num.scm`
- GMP build: `./configure --enable-gmp-bignum`, `make -j6 from-scratch`
- GMP build detected `gmp.h` and `__gmpz_mul` in `-lgmp`
- GMP generated `lib/_num.c` contains the `___USE_GMP_BIGNUM` guards and `mpz_mul` calls
- `GAMBITLIB_DEFS` contains `-D___USE_GMP_BIGNUM` in `makefile`, `lib/makefile`, and `lib/module-common.mk`
- `_num.o` compile lines include `-D___USE_GMP_BIGNUM`
- GMP targeted number test passed: `../gsi/gsi -:tl,~~bin=../bin,~~lib=../lib,~~include=../include -f ./run-unit-tests.scm unit-tests/03-number/_num.scm`
- after rebasing on current `master`: `git diff --check origin/master...HEAD`

A local bignum multiplication/squaring probe used non-sparse operands and checked result tails modulo `1000000007`; the default and GMP builds produced matching tails.

| Case | Default real | GMP real | Speedup | Default allocation | GMP allocation |
| --- | ---: | ---: | ---: | ---: | ---: |
| 50k-bit multiply, 20 reps | `0.019825s` | `0.000939s` | `21.1x` | `8,127,200` | `254,080` |
| 50k-bit square, 20 reps | `0.013814s` | `0.000669s` | `20.6x` | `5,503,200` | `254,080` |
| 200k-bit multiply, 5 reps | `0.021878s` | `0.001537s` | `14.2x` | `8,117,880` | `251,360` |
| 200k-bit square, 5 reps | `0.015129s` | `0.001080s` | `14.0x` | `5,495,840` | `251,400` |

Disclosure: I used Codex (GPT-5.5 xHigh) for a final code review pass after human programming.