### PR TITLE
Add print and println unit tests

### DIFF
--- a/tests/unit-tests/09-io/print.scm
+++ b/tests/unit-tests/09-io/print.scm
@@ -13,6 +13,11 @@
  (with-output-to-string (lambda () (print 1 2 3))))
 
 (test-equal
+ "1234567"
+ (with-output-to-string
+  (lambda () (print 1 (list (cons 2 3) (vector 4 5) 6) 7))))
+
+(test-equal
  "123"
  (call-with-output-string (lambda (port) (print port: port 1 2 3))))
 
@@ -27,6 +32,11 @@
 (test-equal
  "123\n"
  (with-output-to-string (lambda () (println 1 2 3))))
+
+(test-equal
+ "1234567\n"
+ (with-output-to-string
+  (lambda () (println 1 (list (cons 2 3) (vector 4 5) 6) 7))))
 
 (test-equal
  "123\n"

--- a/tests/unit-tests/09-io/print.scm
+++ b/tests/unit-tests/09-io/print.scm
@@ -1,0 +1,36 @@
+(include "#.scm")
+
+(test-equal
+ ""
+ (with-output-to-string (lambda () (print))))
+
+(test-equal
+ "123"
+ (with-output-to-string (lambda () (print 123))))
+
+(test-equal
+ "123"
+ (with-output-to-string (lambda () (print 1 2 3))))
+
+(test-equal
+ "123"
+ (call-with-output-string (lambda (port) (print port: port 1 2 3))))
+
+(test-equal
+ "\n"
+ (with-output-to-string (lambda () (println))))
+
+(test-equal
+ "123\n"
+ (with-output-to-string (lambda () (println 123))))
+
+(test-equal
+ "123\n"
+ (with-output-to-string (lambda () (println 1 2 3))))
+
+(test-equal
+ "123\n"
+ (call-with-output-string (lambda (port) (println port: port 1 2 3))))
+
+(test-error-tail type-exception? (print port: #f 123))
+(test-error-tail type-exception? (println port: #f 123))


### PR DESCRIPTION
This adds direct `09-io` unit tests for `print` and `println`.

The new tests cover:
- default output port
- explicit `port:` output
- zero, one, and multiple arguments
- invalid output port errors

This is a small step toward #756. It does not touch the tested-procedure listing infrastructure; #797 already explores that broader direction.

Tests:
- `gsi -:=../.. 09-io/print.scm`
- `GAMBIT_COVERAGE=yes gsi -:=../.. 09-io/print.scm`
- `gsi -:=../.. 09-io/display.scm`
- `gsi -:=../.. 09-io/read_line.scm`
- `git diff --cached --check`

Disclosure: I used Codex (GPT-5.5 xHigh) for a final code review pass after human programming.
