### PR TITLE
Protect sfun stack marker procedure across GC

### DIFF
--- a/lib/c_intf.c
+++ b/lib/c_intf.c
@@ -6521,13 +6521,15 @@ ___SCMOBJ proc_or_false;)
 {
   ___SCMOBJ stack_marker;
 
+  ___GC_SAVE1(___ps, proc_or_false);
+
 #ifdef ___SINGLE_THREADED_VMS
   stack_marker = ___make_vector (___ps, 1, ___FAL);
 #else
   stack_marker = ___make_vector (___ps, 2, ___FAL);
 #endif
 
-  /*TODO: proc_or_false may have been GC'd at this point! protect it some way*/
+  ___GC_RESTORE1(___ps, proc_or_false);
 
   if (___FIXNUMP(stack_marker))
     return ___FIX(___SFUN_HEAP_OVERFLOW_ERR);


### PR DESCRIPTION
Fixes #995.

`___make_sfun_stack_marker` allocates `stack_marker` with `___make_vector` before storing `proc_or_false` in the marker. That allocation can trigger GC, so a movable Scheme procedure passed as `proc_or_false` can be moved before the later local use.

This protects `proc_or_false` across the allocation with `___GC_SAVE1` / `___GC_RESTORE1`, matching the existing runtime pattern for keeping Scheme objects live across allocations that may collect.

Tested with:

- `./configure CC=gcc --enable-smp --enable-multiple-threaded-vms --enable-debug-garbage-collect --enable-default-runtime-options=f8,-8,t8`
- `make -j4 core`
- `./gsi/gsi -:p1`, `-:p2`, and `-:p4` smoke checks
- focused compiled C-interface repro with `-:p1`, `-:p2`, and `-:p4`

Disclosure: I used Codex (GPT-5.5 xHigh) for a final code review pass after human programming.