### PR TITLE
Fix thread termination crash on Windows SMP

### DIFF
--- a/lib/_thread.scm
+++ b/lib/_thread.scm
@@ -1587,13 +1587,18 @@
 
   (##declare (not interrupts-enabled))
 
-  ;; acquire low-level lock of thread
-  (macro-lock-current-thread!)
+  (macro-thread-save!
+   (lambda (current-thread exception? result)
 
-  (##thread-end-locked! (macro-current-thread) exception? result)
+     ;; acquire low-level lock of thread
+     (macro-lock-thread! current-thread)
 
-  (macro-processor-current-thread-set! (macro-current-processor) #f)
-  (##thread-schedule!))
+     (##thread-end-locked! current-thread exception? result)
+
+     (macro-processor-current-thread-set! (macro-current-processor) #f)
+     (##thread-schedule!))
+   exception?
+   result))
 
 (define-prim (##thread-end-locked! thread exception? result)
 

--- a/tests/unit-tests/06-thread/issue_326.scm
+++ b/tests/unit-tests/06-thread/issue_326.scm
@@ -1,0 +1,19 @@
+(include "#.scm")
+
+(if (= (##current-vm-processor-count) 2)
+    (let* ((started? #f)
+           (t
+            (thread-start!
+             (make-thread
+              (lambda ()
+                (set! started? #t)
+                (let loop ()
+                  (##void)
+                  (loop)))))))
+      (let wait ()
+        (if (not started?)
+            (begin
+              (thread-yield!)
+              (wait))))
+      (check-equal? (thread-terminate! t) (void)))
+    (check-equal? #t #t))


### PR DESCRIPTION
Fixes #326.

Part of #760.

## Summary

- save the current thread before ending it and transferring control back to the scheduler
- add a regression test for terminating a running thread in a two-processor runtime

## Testing

- Windows/w64devkit: `./configure --enable-smp --enable-multiple-threaded-vms`
- Windows/w64devkit: `make core`
- Windows/w64devkit: `gsi -:p2,debug-settings=-,io-settings=lu,~~bin=../bin,~~lib=../lib,~~include=../include -f unit-tests/06-thread/issue_326.scm`
- Windows/w64devkit: `gsi -:p2,h64M,debug-settings=-,io-settings=lu,~~bin=../bin,~~lib=../lib,~~include=../include -f unit-tests/06-thread/thread_terminate.scm`
- Windows/w64devkit repro loop: `p1` 10/10, `p2` 50/50, `p3,h512M` 20/20, `p4,h512M` 20/20

Disclosure: I used Codex (GPT-5.5 xHigh) for a final code review pass after human programming.
