### PR TITLE
Fix SMP stack break marker after continuation moves

### DIFF
--- a/lib/mem.c
+++ b/lib/mem.c
@@ -6246,7 +6246,12 @@ ___PSDKR)
 
   alloc_stack_ptr = p2;
 
-  ___FP_SET_STK(alloc_stack_ptr,
+  /*
+   * The copied first break frame is at stack_break; alloc_stack_ptr now
+   * points to the copied current frame.
+   */
+
+  ___FP_SET_STK(___ps->stack_break,
                 -___FIRST_BREAK_FRAME_STACK_MSECTION,
                 ___CAST(___WORD,
                         ___CAST(___msection*,NULL))) /* not a stack section overflow */
@@ -7235,6 +7240,13 @@ ___PSDKR)
        */
 
       ___FP_ADJFP(alloc_stack_ptr,___FIRST_BREAK_FRAME_SPACE)
+
+      /* The field is only non-NULL for a real stack section overflow. */
+
+      ___FP_SET_STK(alloc_stack_ptr,
+                    -___FIRST_BREAK_FRAME_STACK_MSECTION,
+                    ___CAST(___WORD,
+                            ___CAST(___msection*,NULL)))
 
       /*
        * Because ___stack_limit is only called by the stack-limit


### PR DESCRIPTION
Fixes a stale first-break-frame marker in the SMP stack movement path.

When a continuation stack is moved during GC, the copied first break frame lives at the new `stack_break`, while `alloc_stack_ptr` points at the copied current frame. The stack-section marker was being cleared through `alloc_stack_ptr`, which could leave the copied first break frame with a stale stack msection pointer. With concurrent SMP stack pressure this can later make the stack overflow undo path restore an invalid stack section and crash in the break handler.

This also initializes the same marker when `___stack_limit` creates a fresh first break frame in a new stack msection. The marker remains `NULL` for the normal path, and is only non-NULL when the frame represents a real stack section overflow.

Closes #375.
Related to #760.

Validation:
- `./configure --enable-smp --enable-multiple-threaded-vms`
- `make -j8 core`
- Ackermann/thread-yield SMP stress repro:
  - baseline before the fix: `-:p2`, `n=8`, 4 threads: 1/5 passed, 4/5 SIGSEGV
  - with this fix: `-:p2`, `n=8`: 70/70 passed
  - with this fix: `-:p4`, `n=8`: 70/70 passed
  - with this fix: `-:p8`, `n=8`: 30/30 passed
  - with this fix: `-:p2`, `n=9`: 20/20 passed
  - with this fix: `-:p4`, `n=9`: 20/20 passed
  - with this fix: `-:p8`, `n=9`: 10/10 passed
- `git diff --check`

Disclosure: I used Codex (GPT-5.5 xHigh) for a final code review pass after human programming.
