### PR TITLE
Fix SMP mailbox races that drop messages

### DIFF
--- a/lib/_thread.scm
+++ b/lib/_thread.scm
@@ -3258,10 +3258,18 @@
   (##declare (not interrupts-enabled))
   (or (macro-thread-mailbox thread)
       (let ((mb (macro-make-mailbox)))
-        (or (macro-thread-mailbox thread)
-            (begin
-              (macro-thread-mailbox-set! thread mb)
-              mb)))))
+        ;; Multiple senders can concurrently initialize a thread's mailbox.
+        ;; Serialize the final check and installation so every sender uses the
+        ;; same mailbox.  Allocate before taking the low-level lock because a
+        ;; garbage collection must not occur while that lock is held.
+        (macro-lock-thread! thread)
+        (let ((result
+               (or (macro-thread-mailbox thread)
+                   (begin
+                     (macro-thread-mailbox-set! thread mb)
+                     mb))))
+          (macro-unlock-thread! thread)
+          result))))
 
 (define-prim (##thread-mailbox-rewind)
   (##declare (not interrupts-enabled))
@@ -3276,16 +3284,21 @@
   (##declare (not interrupts-enabled))
   (let* ((mb
           (##thread-mailbox-get! (macro-current-thread)))
-         (cursor
-          (macro-mailbox-cursor mb)))
-    (if cursor
-      (let* ((next (macro-fifo-next cursor))
-             (next2 (macro-fifo-next next)))
-        (macro-fifo-next-set! cursor next2)
-        (if (##not (##pair? next2))
-          (macro-fifo-tail-set! (macro-mailbox-fifo mb) cursor))
-        (macro-mailbox-cursor-set! mb #f)))
-    (##void)))
+         (mutex
+          (macro-mailbox-mutex mb)))
+    (macro-mutex-lock! mutex #f (macro-current-thread))
+    (let ((cursor (macro-mailbox-cursor mb)))
+      (if cursor
+        (let* ((next (macro-fifo-next cursor))
+               (next2 (macro-fifo-next next)))
+          (macro-fifo-next-set! cursor next2)
+          (if (##not (##pair? next2))
+            (macro-fifo-tail-set! (macro-mailbox-fifo mb) cursor))
+          (macro-mailbox-cursor-set! mb #f))))
+    (macro-mutex-unlock! mutex)
+    (let ()
+      (declare (interrupts-enabled))
+      (##void))))
 
 (define-prim (thread-mailbox-extract-and-rewind)
   (##thread-mailbox-extract-and-rewind))
@@ -3296,69 +3309,52 @@
               absrel-timeout
               timeout-val)
   (##declare (not interrupts-enabled))
-  (let* ((mb
-          (##thread-mailbox-get! (macro-current-thread)))
-         (cursor
-          (macro-mailbox-cursor mb))
-         (next
-          (if cursor
-            (macro-fifo-next cursor)
-            (macro-mailbox-fifo mb)))
-         (next2
-          (macro-fifo-next next)))
-    (if (##pair? next2)
-      (let ((result (macro-fifo-elem next2)))
-        (if extract-and-rewind?
-          (let ((next3 (macro-fifo-next next2)))
-            (macro-fifo-next-set! next next3)
-            (if (##not (##pair? next3))
-              (macro-fifo-tail-set! (macro-mailbox-fifo mb) next))
-            (macro-mailbox-cursor-set! mb #f))
-          (macro-mailbox-cursor-set! mb next))
-        result)
-      (let ((timeout
-             (##absrel-timeout->timeout
-              (if (##eq? absrel-timeout (macro-absent-obj))
-                #f
-                absrel-timeout))))
-        (let loop ()
-          (let* ((mb
-                  (##thread-mailbox-get! (macro-current-thread)))
-                 (mutex
-                  (macro-mailbox-mutex mb)))
-            (macro-mutex-lock! mutex #f (macro-current-thread))
-            (let* ((cursor
-                    (macro-mailbox-cursor mb))
-                   (next
-                    (if cursor
-                      (macro-fifo-next cursor)
-                      (macro-mailbox-fifo mb)))
-                   (next2
-                    (macro-fifo-next next)))
-              (if (##pair? next2)
-                (let ((result (macro-fifo-elem next2)))
-                  (if extract-and-rewind?
-                    (let ((next3 (macro-fifo-next next2)))
-                      (macro-fifo-next-set! next next3)
-                      (if (##not (##pair? next3))
-                        (macro-fifo-tail-set! (macro-mailbox-fifo mb) next))
-                      (macro-mailbox-cursor-set! mb #f))
-                    (macro-mailbox-cursor-set! mb next))
-                  (macro-mutex-unlock! mutex)
-                  (let ()
-                    (declare (interrupts-enabled))
-                    result))
-                (if (##mutex-signal-and-condvar-wait!
-                     mutex
-                     (macro-mailbox-condvar mb)
-                     timeout)
-                  (loop)
-                  (if (##eq? timeout-val (macro-absent-obj))
-                    (##raise-mailbox-receive-timeout-exception
-                     prim
-                     absrel-timeout
-                     timeout-val)
-                    timeout-val))))))))))
+  (let ((timeout
+         (##absrel-timeout->timeout
+          (if (##eq? absrel-timeout (macro-absent-obj))
+            #f
+            absrel-timeout))))
+    (let loop ()
+      (let* ((mb
+              (##thread-mailbox-get! (macro-current-thread)))
+             (mutex
+              (macro-mailbox-mutex mb)))
+        ;; Senders update the same FIFO while holding this mutex.  The old
+        ;; nonempty fast path skipped the mutex, so a receive racing the final
+        ;; link/tail updates of thread-send could detach messages.
+        (macro-mutex-lock! mutex #f (macro-current-thread))
+        (let* ((cursor
+                (macro-mailbox-cursor mb))
+               (next
+                (if cursor
+                  (macro-fifo-next cursor)
+                  (macro-mailbox-fifo mb)))
+               (next2
+                (macro-fifo-next next)))
+          (if (##pair? next2)
+            (let ((result (macro-fifo-elem next2)))
+              (if extract-and-rewind?
+                (let ((next3 (macro-fifo-next next2)))
+                  (macro-fifo-next-set! next next3)
+                  (if (##not (##pair? next3))
+                    (macro-fifo-tail-set! (macro-mailbox-fifo mb) next))
+                  (macro-mailbox-cursor-set! mb #f))
+                (macro-mailbox-cursor-set! mb next))
+              (macro-mutex-unlock! mutex)
+              (let ()
+                (declare (interrupts-enabled))
+                result))
+            (if (##mutex-signal-and-condvar-wait!
+                 mutex
+                 (macro-mailbox-condvar mb)
+                 timeout)
+              (loop)
+              (if (##eq? timeout-val (macro-absent-obj))
+                (##raise-mailbox-receive-timeout-exception
+                 prim
+                 absrel-timeout
+                 timeout-val)
+                timeout-val))))))))
 
 (define-prim (thread-mailbox-next
               #!optional

--- a/tests/unit-tests/06-thread/thread_mailbox_concurrent.scm
+++ b/tests/unit-tests/06-thread/thread_mailbox_concurrent.scm
@@ -1,0 +1,106 @@
+(include "#.scm")
+
+(cond-expand
+ (enable-smp
+
+  (define senders 4)
+
+  (##cvmr senders)
+
+  (define (test-concurrent-mailbox-initialization)
+    (define trials 2000)
+    (define ready-a (make-vector trials #f))
+    (define ready-b (make-vector trials #f))
+    (define receivers
+      (let ((result (make-vector trials)))
+        (let loop ((i 0))
+          (if (< i trials)
+              (begin
+                (vector-set!
+                 result
+                 i
+                 (make-thread
+                  (lambda ()
+                    (let ((first (thread-receive 2.0 'timeout))
+                          (second (thread-receive 2.0 'timeout)))
+                      (+ (if (eq? first 'timeout) 0 1)
+                         (if (eq? second 'timeout) 0 1))))))
+                (loop (+ i 1)))))
+        result))
+    (define (send-all mine other value)
+      (let loop ((i 0))
+        (if (< i trials)
+            (begin
+              (vector-set! mine i #t)
+              (let wait ()
+                (if (not (vector-ref other i))
+                    (begin
+                      (thread-yield!)
+                      (wait))))
+              (thread-send (vector-ref receivers i) value)
+              (loop (+ i 1))))))
+    (let ((sender-a
+           (make-thread (lambda () (send-all ready-a ready-b 'a))))
+          (sender-b
+           (make-thread (lambda () (send-all ready-b ready-a 'b)))))
+      (##thread-pin! sender-a (##processor 1))
+      (##thread-pin! sender-b (##processor 2))
+      (thread-start! sender-a)
+      (thread-start! sender-b)
+      (thread-join! sender-a)
+      (thread-join! sender-b))
+    (let start ((i 0))
+      (if (< i trials)
+          (begin
+            (thread-start! (vector-ref receivers i))
+            (start (+ i 1)))))
+    (let count ((i 0) (received 0))
+      (if (= i trials)
+          received
+          (count (+ i 1)
+                 (+ received (thread-join! (vector-ref receivers i)))))))
+
+  (test-equal 4000 (test-concurrent-mailbox-initialization))
+
+  (define messages-per-sender 25000)
+  (define expected (* senders messages-per-sender))
+
+  (define receiver
+    (make-thread
+     (lambda ()
+       (let loop ((received 0))
+         (if (= received expected)
+             received
+             (let ((message (thread-receive 2.0 'timeout)))
+               (if (eq? message 'timeout)
+                   received
+                   (loop (+ received 1)))))))))
+
+  (define sender-threads
+    (let loop ((id 0) (result '()))
+      (if (= id senders)
+          result
+          (loop
+           (+ id 1)
+           (cons
+            (make-thread
+             (lambda ()
+               (let send ((remaining messages-per-sender))
+                 (if (> remaining 0)
+                     (begin
+                       (thread-send receiver id)
+                       (send (- remaining 1)))))))
+            result)))))
+
+  (##thread-pin! receiver (##processor 0))
+  (let pin ((threads sender-threads) (processor-id 1))
+    (if (pair? threads)
+        (begin
+          (##thread-pin! (car threads) (##processor processor-id))
+          (pin (cdr threads) (+ 1 (modulo processor-id 3))))))
+  (thread-start! receiver)
+  (for-each thread-start! sender-threads)
+  (for-each thread-join! sender-threads)
+  (test-equal expected (thread-join! receiver)))
+
+ (else))


### PR DESCRIPTION
Concurrent sends can lose messages in SMP builds in two ways:

- Two processors can race while lazily creating the destination thread's mailbox. Each can publish a different mailbox and send to the one that is subsequently replaced.
- The nonempty receive path rewrites the mailbox FIFO without its mutex while `thread-send` updates the same FIFO under that mutex. A receive can therefore detach messages inserted by another processor.

This change allocates a candidate mailbox before taking the thread lock, performs the final check and installation under that lock, and protects receive/extract FIFO mutations with the mailbox mutex. It also adds a pinned four-processor regression covering both first-use initialization and sustained concurrent send/receive.

### Focused validation

Built current source with:

```
./configure --enable-smp --enable-multiple-threaded-vms --enable-c-opt=-O1
make bootstrap
make core
```

Then ran:

```
../../../gsi/gsi -:m256M thread_mailbox_concurrent.scm
```

On pristine `master` (`ab6f255c3ca8757816549ff092829d46896927b3`), the test failed with:

- concurrent initialization: 3,672 / 4,000 messages received
- concurrent send/receive: 5,741 / 100,000 messages received

With this patch, both phases receive all 104,000 messages on repeated runs.

This PR is intended as a claim for one of the 100 EUR SMP bounties described in #760 if the fix is accepted.

Disclosure: This implementation, testing, and PR text were produced through human-directed collaboration with OpenAI Codex.