### PR TITLE
Reset SMP thread quantum on yield and blocking waits

### DIFF
--- a/lib/_thread.scm
+++ b/lib/_thread.scm
@@ -1895,8 +1895,9 @@
 
       (lambda (current-thread)
 
-        ;;TODO: reenable
-        ;;(macro-thread-unboost-and-clear-quantum-used! current-thread)
+        ;; Start a fresh quantum after yielding. Priority unboosting
+        ;; remains disabled until SMP priority inheritance is supported.
+        (macro-thread-quantum-used-set! current-thread (macro-inexact-+0))
 
         (macro-thread-resume-thunk-set!
          current-thread
@@ -1919,8 +1920,8 @@
 
      ;; Fast case where only the current thread is runnable.
 
-     ;;TODO: reenable
-     ;;(macro-thread-unboost-and-clear-quantum-used! (macro-current-thread))
+     ;; Even without another runnable thread, yielding ends the quantum.
+     (macro-thread-quantum-used-set! (macro-current-thread) (macro-inexact-+0))
 
      ;; release low-level lock of processor
      (macro-unlock-current-processor!)

--- a/lib/_thread.scm
+++ b/lib/_thread.scm
@@ -3734,10 +3734,8 @@
                              (##lock-2-threads! current-thread new-owner)
                              (macro-lock-thread! current-thread))
 
-                         ;;TODO: reenable
-                         #;
-                         (macro-thread-boost-and-clear-quantum-used!
-                          current-thread)
+                         ;; Blocking ends the current quantum.
+                         (macro-thread-quantum-used-set! current-thread (macro-inexact-+0))
 
                          ;; save new-owner in thread so that mutex-unlock!
                          ;; can use this information when thread ends waiting
@@ -4019,10 +4017,8 @@
                 ;; acquire low-level lock of the current thread
                 (macro-lock-thread! current-thread)
 
-                ;;TODO: reenable
-                #;
-                (macro-thread-boost-and-clear-quantum-used!
-                 current-thread)
+                ;; Blocking ends the current quantum.
+                (macro-thread-quantum-used-set! current-thread (macro-inexact-+0))
 
                 ;; add current thread to blocked thread queue
                 ;; of the condition variable
@@ -4110,10 +4106,8 @@
                  current-thread
                  ##thread-void-action!)
 
-                ;;TODO: reenable
-                #;
-                (macro-thread-boost-and-clear-quantum-used!
-                current-thread)
+                ;; Blocking ends the current quantum.
+                (macro-thread-quantum-used-set! current-thread (macro-inexact-+0))
 
                 (##thread-btq-insert! condvar current-thread)
 

--- a/lib/_thread.scm
+++ b/lib/_thread.scm
@@ -1800,8 +1800,8 @@
                                  current-thread
                                  ##thread-void-action!)
 
-                                ;;TODO: reenable
-                                ;;(macro-thread-unboost-and-clear-quantum-used! current-thread)
+                                ;; Blocking ends the current quantum.
+                                (macro-thread-quantum-used-set! current-thread (macro-inexact-+0))
 
                                 ;; suspend current thread on end-condvar
                                 (##thread-btq-insert! end-condvar current-thread)
@@ -1974,10 +1974,8 @@
                      current-thread
                      ##thread-void-action!)
 
-                    ;;TODO:reenable
-                    #;
-                    (macro-thread-unboost-and-clear-quantum-used!
-                    current-thread)
+                    ;; Blocking ends the current quantum.
+                    (macro-thread-quantum-used-set! current-thread (macro-inexact-+0))
 
                     ;; acquire low-level lock of processor
                     (macro-lock-current-processor!)

--- a/tests/unit-tests/06-thread/thread_quantum_reset.scm
+++ b/tests/unit-tests/06-thread/thread_quantum_reset.scm
@@ -84,5 +84,23 @@
 
 (check-blocking-quantum (lambda () (thread-sleep! 0.001)))
 
+;; A contended mutex resumes with a fresh quantum.
+(check-blocking-quantum
+ (lambda ()
+   (let ((mutex (make-mutex)))
+     (mutex-lock! mutex #f #f)
+     (thread-start! (make-local-thread (lambda () (mutex-unlock! mutex))))
+     (mutex-lock! mutex)
+     (mutex-unlock! mutex))))
+
+;; Waiting for a condition variable also ends the old quantum.
+(check-blocking-quantum
+ (lambda ()
+   (let ((mutex (make-mutex)) (condvar (make-condition-variable)))
+     (mutex-lock! mutex)
+     (thread-start! (make-local-thread
+                     (lambda () (condition-variable-signal! condvar))))
+     (mutex-unlock! mutex condvar))))
+
 (##set-heartbeat-interval! (f64vector-ref saved-heartbeat 0))
 (thread-quantum-set! (current-thread) saved-quantum)

--- a/tests/unit-tests/06-thread/thread_quantum_reset.scm
+++ b/tests/unit-tests/06-thread/thread_quantum_reset.scm
@@ -53,5 +53,36 @@
 (thread-join! b)
 (test-equal '(a a a b b b a a a b b b a a a b b b) (reverse events))
 
+;; Blocking also starts a fresh quantum when the thread resumes.
+(define (check-blocking-quantum block!)
+  (let ((tester
+         (make-local-thread
+          (lambda ()
+            (set! events '())
+            (thread-yield!)
+            (##thread-heartbeat!)
+            (##thread-heartbeat!)
+            (block!)
+            (let ((worker (make-local-thread (lambda () (record! 'worker)))))
+              (thread-start! worker)
+              (##thread-heartbeat!)
+              (record! 'one)
+              (##thread-heartbeat!)
+              (record! 'two)
+              (##thread-heartbeat!)
+              (record! 'three)
+              (thread-join! worker))
+            (test-equal '(one two worker three) (reverse events))))))
+    (thread-start! tester)
+    (thread-join! tester)))
+
+(check-blocking-quantum
+ (lambda ()
+   (let ((worker (make-local-thread (lambda () #t))))
+     (thread-start! worker)
+     (thread-join! worker))))
+
+(check-blocking-quantum (lambda () (thread-sleep! 0.001)))
+
 (##set-heartbeat-interval! (f64vector-ref saved-heartbeat 0))
 (thread-quantum-set! (current-thread) saved-quantum)

--- a/tests/unit-tests/06-thread/thread_quantum_yield.scm
+++ b/tests/unit-tests/06-thread/thread_quantum_yield.scm
@@ -1,0 +1,57 @@
+(include "#.scm")
+
+;; Explicit heartbeats make time-slice accounting independent of CPU speed.
+;; The long timer interval keeps real timer delivery out of these short tests.
+(define saved-heartbeat (make-f64vector 1))
+(##get-heartbeat-interval! saved-heartbeat 0)
+(define saved-quantum (thread-quantum (current-thread)))
+(##set-heartbeat-interval! 1000.0)
+(thread-quantum-set! (current-thread) 3000.0)
+
+(define processor (current-processor))
+(define (make-local-thread thunk)
+  (let ((thread (make-thread thunk)))
+    (cond-expand
+     (enable-smp (##thread-pin! thread processor))
+     (else #f))
+    thread))
+
+;; A yield with no other runnable thread must also start a fresh quantum.
+(thread-yield!)
+(##thread-heartbeat!)
+(##thread-heartbeat!)
+(thread-yield!)
+(define events '())
+(define (record! event) (set! events (cons event events)))
+(define worker (make-local-thread (lambda () (record! 'worker))))
+(thread-start! worker)
+(##thread-heartbeat!)
+(record! 'one)
+(##thread-heartbeat!)
+(record! 'two)
+(##thread-heartbeat!)
+(record! 'three)
+(thread-join! worker)
+(test-equal '(one two worker three) (reverse events))
+
+;; Every quantum, not just the first, must last for three heartbeats.
+(set! events '())
+(define (make-worker name)
+  (make-local-thread
+   (lambda ()
+     (let loop ((n 0))
+       (if (< n 9)
+           (begin
+             (record! name)
+             (##thread-heartbeat!)
+             (loop (+ n 1))))))))
+(define a (make-worker 'a))
+(define b (make-worker 'b))
+(thread-start! a)
+(thread-start! b)
+(thread-join! a)
+(thread-join! b)
+(test-equal '(a a a b b b a a a b b b a a a b b b) (reverse events))
+
+(##set-heartbeat-interval! (f64vector-ref saved-heartbeat 0))
+(thread-quantum-set! (current-thread) saved-quantum)


### PR DESCRIPTION
SMP threads retain consumed quantum across yields and blocking waits because the combined priority-adjustment/quantum-reset operations were disabled. After resuming, a thread receives only the remainder of its old time slice. Equal-priority threads consequently switch on every heartbeat after consuming their first quantum.

Reset only the quantum counter at seven sites while the current thread is locked: both yield paths, blocking join, sleep, mutex acquisition, condition-variable wait, and device I/O wait. Priority boosting/unboosting stays disabled.

The checked-in regression uses explicit heartbeats for deterministic three-tick quanta and pins SMP workers to one processor. Its six cases cover both yield paths and join, sleep, mutex and condition-variable waits. For example, repeated equal-priority execution changes from `(a a a b b b a b a b ...)` to fresh three-tick slices `(a a a b b b a a a b b b ...)`.

Validation on macOS arm64, based on `e0236bccd8c2a06c315c2970c21e3dae8673b0bb`:

- All six checked-in cases pass on unicore and fail on the original SMP runtime at p1/p2/p4. The earlier four-site patch still fails the two newly added mutex/condition-variable cases.
- Final interpreted regression: 100/100 passes each with `-:p1,m64M`, `-:p2,m64M`, and `-:p4,m64M` (300 fresh processes).
- Final native-compiled regression passes at p1, p2, and p4.
- A separate Unix-only local-process control exercises device I/O by reading from `/bin/sh -c 'sleep 0.02; printf x'` after consuming two heartbeat ticks. It fails before the I/O reset and passes afterward; the seven-case control passed another 100/100 runs at each p1/p2/p4. This control is not part of the portable checked-in suite.
- Re-ran 23 existing `06-thread` files at p1 and p4. Baseline: 22/23 at p1 and 21/23 at p4. Final patch: 22/23 at p1 and 23/23 at p4. Both versions hit the timing-sensitive inactive-thread exception in `thread_interrupt.scm` at p1. Baseline p4 crashed in `mutex_race_timeout.scm` and `thread_yield.scm`; earlier runs also observed intermittent mutex crashes in patched builds. These focused checks do not certify the entire SMP suite.

The runtime uses `--enable-smp --enable-multiple-threaded-vms --enable-c-opt=-O1`. The modified Scheme module was regenerated with the matching feature prelude, compiled with the build's C flags, and relinked. Temporary source copies avoided local filesystem hydration delays.

Run with the rebuilt runtime:

```sh
gsi -:p4,m64M tests/unit-tests/06-thread/thread_quantum_reset.scm
```

For consideration under #760 as **one** related quantum-accounting fix, subject to maintainer adoption and sponsor confirmation that an award remains available. PayPal would be the preferred payout method; details can be provided privately if an award is approved. No award or payment agreement is assumed.
