### PR TITLE
Fix SMP in-memory pipe hangs by sharing the endpoint mutex

### DIFF
--- a/lib/_io.scm
+++ b/lib/_io.scm
@@ -3023,6 +3023,10 @@
                  (wbuf2 (,macro-vect-port-wbuf port2))
                  (whi1 (,macro-vect-port-whi port1))
                  (whi2 (,macro-vect-port-whi port2)))
+             ;; Both endpoints access shared buffers and wait predicates.
+             ;; Serialize them with one mutex so publication cannot race
+             ;; with the peer checking a predicate and beginning to wait.
+             (macro-port-mutex-set! port2 (macro-port-mutex port1))
              (,macro-vect-port-wbuf-set! port1 wbuf2)
              (,macro-vect-port-wbuf-set! port2 wbuf1)
              (,macro-vect-port-whi-set! port1 whi2)

--- a/tests/unit-tests/09-io/pipe_concurrent.scm
+++ b/tests/unit-tests/09-io/pipe_concurrent.scm
@@ -1,0 +1,58 @@
+(include "#.scm")
+
+;; Each endpoint must protect the same shared buffers and wait predicates.
+;; Pin the server to another processor to exercise simultaneous endpoint
+;; access; otherwise wakeups can migrate both conversations to one processor.
+;; Pinning is only a scheduling aid.  The I/O operations are public APIs.
+(define (check-pipe open-pipe read-one write-one)
+  (receive (client server) (open-pipe)
+    (define worker
+      (make-thread
+        (lambda ()
+          (let loop ((i 0))
+            (if (= i 10000)
+                #t
+                (let ((expected (modulo i 251))
+                      (value (read-one server)))
+                  (if (equal? value expected)
+                      (begin
+                        (write-one value server)
+                        (force-output server)
+                        (loop (+ i 1)))
+                      (list 'server i value))))))))
+
+    ;; Bound a lost-wakeup regression instead of waiting forever for a read.
+    (input-port-timeout-set! client 10)
+    (input-port-timeout-set! server 10)
+
+    (if (> (##current-vm-processor-count) 1)
+        (begin
+          (##thread-pin! (current-thread) (##processor 0))
+          (##thread-pin! worker (##processor 1))))
+    (thread-start! worker)
+
+    (let ((result
+           (let loop ((i 0))
+             (if (= i 10000)
+                 #t
+                 (let ((expected (modulo i 251)))
+                   (write-one expected client)
+                   (force-output client)
+                   (let ((value (read-one client)))
+                     (if (equal? value expected)
+                         (loop (+ i 1))
+                         (list 'client i value))))))))
+      (close-output-port client)
+      (test-equal #t result)
+      (test-equal #t (thread-join! worker 12 'worker-timeout)))
+
+    (close-port client)
+    (close-port server)
+    (if (> (##current-vm-processor-count) 1)
+        (##thread-pin! (current-thread) #f))))
+
+(check-pipe open-vector-pipe read write)
+(check-pipe open-string-pipe
+            read
+            (lambda (value port) (write value port) (newline port)))
+(check-pipe open-u8vector-pipe read-u8 write-u8)


### PR DESCRIPTION
Concurrent request/reply over `open-vector-pipe`, `open-string-pipe`, and `open-u8vector-pipe` can stop making progress when the two endpoints run on separate SMP processors. Assign both endpoints the same mutex before connecting their buffers, so peer buffer access and the predicate-to-condition-wait transition are protected by the same lock.

The generated pipe constructor previously gave each endpoint its own mutex. `vect-rbuf-fill` reads the peer's buffer/close state and can begin waiting while the peer publishes data or signals under a different lock. The existing fill/drain/force-output/close paths already lock an endpoint and release that lock when waiting; sharing the mutex makes those operations synchronize with each other. The change covers the three pipe types through the common constructor.

Adds `09-io/pipe_concurrent.scm`: 10,000 request/reply exchanges for each pipe type, with bounded input waits and worker joins. It uses internal `##thread-pin!` only to place the client/server on processors 0/1 when SMP has multiple processors. The I/O operations being tested are public APIs. Unpinned probes passed in this environment, so the regression deliberately supplies the scheduling condition needed to reproduce the failure.

Validation on macOS arm64, base `dcd677cd3e40860bdd27dfbdbf5e3ce46ab03813`, SMP configured with `--enable-smp --enable-multiple-threaded-vms --enable-c-opt=-O1`:

- Preserved baseline SMP runtime: the regression failed for all three pipe types at their 10-second input deadlines. The original vector-only reproducer also timed out after 20 seconds, with three fresh progress-logged repetitions timing out after 5 seconds. Unicore and SMP with one processor completed that reproducer.
- Patched runtime: the unchanged original reproducer and the new three-type regression pass at `-:p1,m64M`, `-:p2,m64M`, and `-:p4,m64M`. Five additional fresh p2 runs of the three-type regression passed. The regression also passes on the existing unicore runtime.
- `09-io/pipe_concurrent.scm` and existing `09-io/vect_port.scm` pass interpreted and compiled through the repository runner at p2.
- Full `09-io` run: 34/35 pass interpreted and 33/35 compiled. `write_read.scm` fails table deserialization; that failure also reproduces with the unchanged baseline runtime. Compiled `write_shared.scm` encountered signal 11, and a focused compilation with the SMP compiler also encountered signal 11. Compiling the unchanged test with the existing unicore compiler succeeded, and that identical module passed on both baseline and patched SMP runtimes. The full suite is therefore not reported as green.

To run the regression from `tests/` (substitute `-gsc` for compiled mode):

```sh
GAMBOPT=p2,m64M ../gsi/gsi -:tl,~~bin=../bin,~~lib=../lib,~~include=../include -f ./run-unit-tests.scm -gsi unit-tests/09-io/pipe_concurrent.scm
```

The two-file change contains the Scheme source and regression only. Generated C/build products are excluded. Submitted for consideration as one shared-constructor correctness fix under #760.
