### PR TITLE
Rehash decoded eq? tables before lookup in SMP builds

### DIFF
--- a/lib/_system.scm
+++ b/lib/_system.scm
@@ -1523,11 +1523,12 @@ end-of-code
             (begin
               (macro-gc-hash-table-flags-set!
                gcht
-               (fxior ;; force rehash at next access!
+               (fxior ;; decoded entries are not in hash order
                 flags
                 (##fx+ (macro-gc-hash-table-flag-key-moved)
                        (macro-gc-hash-table-flag-need-rehash))))
-              gcht))))))
+              ;; SMP builds rehash eagerly, so access will not repair this.
+              (##gc-hash-table-rehash! gcht gcht)))))))
 
 (define-prim (##smallest-prime-no-less-than n) ;; n >= 3
   (let loop1 ((n (if (##fxeven? n) (##fx+ n 1) n)))
@@ -4256,11 +4257,12 @@ end-of-code
                                              (begin
                                                (macro-gc-hash-table-flags-set!
                                                 obj
-                                                (fxior ;; force rehash at next access!
+                                                (fxior ;; decoded entries are not in hash order
                                                  flags
                                                  (fx+ (macro-gc-hash-table-flag-key-moved)
                                                       (macro-gc-hash-table-flag-need-rehash))))
-                                               obj)))
+                                               ;; Rebuild before publishing the decoded table.
+                                               (##gc-hash-table-rehash! obj obj))))
                                        (err)))))))
 
                         ((fx= x (homvector-tag))

--- a/lib/mem.c
+++ b/lib/mem.c
@@ -6184,6 +6184,38 @@ ___SCMOBJ ht_dst;)
   int size2 = words - ___GCHASHTABLE_KEY0;
   int i;
 
+  if (___EQP(ht_src, ht_dst))
+    {
+      ___BOOL mem_alloc_keys =
+        !___FIXZEROP(___FIXAND(body_src[___GCHASHTABLE_FLAGS],
+                                ___FIX(___GCHASHTABLE_FLAG_MEM_ALLOC_KEYS)));
+
+      /*
+       * The in-place GC rehasher requires uniformly allocated or
+       * nonallocated keys.  General Scheme tables can mix both kinds;
+       * their NEED_REHASH flag lets table-access rebuild them using
+       * the table's own hash function instead.
+       */
+
+      for (i=size2-2; i>=0; i-=2)
+        {
+          ___SCMOBJ key = body_src[i+___GCHASHTABLE_KEY0];
+
+          if (key != ___UNUSED &&
+              key != ___DELETED &&
+              (!!___MEM_ALLOCATED(key) != mem_alloc_keys))
+            {
+              body_src[___GCHASHTABLE_FLAGS] =
+                ___FIXAND(body_src[___GCHASHTABLE_FLAGS],
+                          ___FIXNOT(___FIX(___GCHASHTABLE_FLAG_KEY_MOVED)));
+              return ht_dst;
+            }
+        }
+
+      gc_hash_table_rehash_in_situ (ht_src);
+      return ht_dst;
+    }
+
   if (___FIXZEROP(___FIXAND(body_src[___GCHASHTABLE_FLAGS],
                             ___FIX(___GCHASHTABLE_FLAG_UNION_FIND))))
     {

--- a/tests/unit-tests/10-tables/serialization.scm
+++ b/tests/unit-tests/10-tables/serialization.scm
@@ -1,0 +1,71 @@
+(include "#.scm")
+
+(define (text-roundtrip obj)
+  (let ((text
+         (with-output-to-string ""
+           (lambda ()
+             (output-port-readtable-set!
+              (current-output-port)
+              (readtable-sharing-allowed?-set
+               (output-port-readtable (current-output-port)) 'serialize))
+             (write obj)))))
+    (with-input-from-string text read)))
+
+(define (binary-roundtrip obj)
+  (u8vector->object (object->u8vector obj)))
+
+;; Keep the keys in the serialized graph so identity-based tables can be
+;; queried with the corresponding deserialized objects, including heap keys.
+(define (check-roundtrip roundtrip test)
+  (let ((keys (vector 'alpha 123 #f #\a "string-key" '(1 2) '#(3 4)
+                      (if (eq? test eq?) 'omega 1.25)))
+        (table (make-table test: test init: 'missing)))
+    (let add ((i 0))
+      (if (< i (vector-length keys))
+          (begin
+            (table-set! table (vector-ref keys i) (+ i 100))
+            (add (+ i 1)))))
+    (let* ((copy (roundtrip (vector keys table)))
+           (copy-keys (vector-ref copy 0))
+           (copy-table (vector-ref copy 1)))
+      (test-equal (vector-length keys) (table-length copy-table))
+      (let check ((i 0))
+        (if (< i (vector-length keys))
+            (begin
+              (test-equal (+ i 100)
+                          (table-ref copy-table (vector-ref copy-keys i)))
+              (check (+ i 1)))))
+      (test-equal 'missing (table-ref copy-table 'absent-key))
+      (table-set! copy-table 'alpha 'updated)
+      (test-equal 'updated (table-ref copy-table 'alpha))
+      (table-set! copy-table 123)
+      (test-equal 'missing (table-ref copy-table 123))
+      ;; Exercise insertion and resizing after the decoded entries exist.
+      (let add ((i 0))
+        (if (< i 100)
+            (begin
+              (table-set! copy-table (+ i 1000) (* i 7))
+              (add (+ i 1)))))
+      (let check ((i 0))
+        (if (< i 100)
+            (begin
+              (test-equal (* i 7) (table-ref copy-table (+ i 1000)))
+              (check (+ i 1)))))
+      (test-equal 107 (table-length copy-table)))))
+
+(for-each
+ (lambda (roundtrip)
+   (for-each (lambda (test) (check-roundtrip roundtrip test))
+             (list eq? eqv? equal?))
+   (let ((empty (roundtrip (make-table test: eq? init: 'missing))))
+     (test-equal 0 (table-length empty))
+     (test-equal 'missing (table-ref empty 'absent-key))))
+ (list text-roundtrip binary-roundtrip))
+
+;; Binary serialization supports references back to the containing table.
+(let ((table (make-table test: eq?)))
+  (table-set! table table 'self-key)
+  (table-set! table 'self-value table)
+  (let ((copy (binary-roundtrip table)))
+    (test-equal 'self-key (table-ref copy copy))
+    (test-eq copy (table-ref copy 'self-value))))


### PR DESCRIPTION
Serialized `eq?` tables can lose lookup access to entries in an SMP build even with one processor. The text and binary decoders lay out entries sequentially and mark them for a later rehash, but multiple-threaded VM builds disable the access-time lazy rehash path used by `table-ref` for `eq?` tables.

Complete the decoded table's rehash before returning it. The existing `##gc-hash-table-rehash!` primitive now supports identical source and destination tables by using the existing in-place rehasher. That algorithm assumes key allocation tags match the storage kind, so the new path first checks active keys. If a general Scheme table has a different key kind, it clears `KEY_MOVED` and retains `NEED_REHASH` for `table-access` to rebuild with its own hash function. Both the text `##implode-gc-hash-table` and binary `u8vector->object` decoder use this path. This does not enable lazy rehash globally or change table synchronization.

Adds `10-tables/serialization.scm` covering text/binary roundtrips, `eq?`/`eqv?`/`equal?` tests, shared heap keys, immediate keys, defaults, updates, deletion, growth after decoding, empty tables, and binary references back to the containing table.

Validation on macOS arm64, base `dcd677cd3e40860bdd27dfbdbf5e3ce46ab03813`, SMP configured with `--enable-smp --enable-multiple-threaded-vms --enable-c-opt=-O1`:

- A standalone public-API test builds 20 `eq?` tables with 60 symbol/integer keys each and checks every lookup after text and binary roundtrips. Unchanged unicore has zero mismatches. Preserved baseline SMP at p1 and p2 has 863 text mismatches and 368 binary mismatches in the recorded run. The candidate completes with zero mismatches at p1/p2/p4.
- The new regression passes on unchanged unicore and on the candidate at p1/p2/p4; it fails on the preserved baseline SMP runtime.
- All 12 selected interpreted repository tests pass: the entire `10-tables` directory plus `09-io/write_read.scm` and `09-io/write_shared.scm`.
- Compiled: 11/12 pass, including the new regression and `write_read.scm`, which previously failed table lookups. `write_shared.scm` still encounters signal 11 with the SMP compiler, as observed before this change.
- A separate diagnostic that forces GC immediately after decoding fails on both baseline and candidate SMP, while unicore passes; plain GC alone passes both SMP runtimes. This remaining GC limitation is explicitly not claimed fixed. The broader eager-rehash/GC topic also appears in the retracted, unmerged #988. This PR addresses the independently reproduced pre-GC decoder omission.

Run the regression from `tests/` (use `-gsc` for compiled mode):

```sh
GAMBOPT=p2,m64M ../gsi/gsi -:tl,~~bin=../bin,~~lib=../lib,~~include=../include -f ./run-unit-tests.scm -gsi unit-tests/10-tables/serialization.scm
```

This branch contains only the two runtime source files and regression, and was built independently of #1037. Generated C and build products are excluded. Submitted as a second distinct correctness-fix candidate for consideration under #760.
