### PR TITLE
Synchronize shared promise state transitions in SMP builds

### DIFF
--- a/lib/_kernel.scm
+++ b/lib/_kernel.scm
@@ -1858,30 +1858,57 @@ end-of-code
 
 ;;; Implementation of promises.
 
+;; State updates can link two promises, so use one VM-local lock for these
+;; short transitions. Never hold it while evaluating a delayed expression.
+(cond-expand
+ (enable-smp
+  (define-type promise-state-lock
+    id: 13b4ef22-61a7-4aa0-871a-315378451e1f
+    constructor: macro-make-promise-state-lock
+    macros:
+    opaque:
+    (next-ticket init: 0)
+    (current-ticket init: 0))
+  (define ##promise-state-lock (macro-make-promise-state-lock))
+  (define-macro (macro-lock-promise-states!)
+    `(##primitive-lock! ##promise-state-lock 1 2))
+  (define-macro (macro-unlock-promise-states!)
+    `(##primitive-unlock! ##promise-state-lock 1 2)))
+ (else
+  (define-macro (macro-lock-promise-states!) `(##void))
+  (define-macro (macro-unlock-promise-states!) `(##void))))
+
 (define-prim (##force-out-of-line promise)
 
   (declare (not interrupts-enabled))
 
   (define-macro (macro-reentrant-semantics? state) #t)
 
+  (define-macro (macro-unlock-and-return value)
+    `(let ((result ,value))
+       (macro-unlock-promise-states!)
+       result))
+
   (define (nonreentrant-undetermined-case promise)
+    (macro-unlock-promise-states!)
     (error "Attempt to reenter nonreentrant promise" promise))
 
   (define (chase promise thunk)
-    (let ((result1 ;; compute promise's value by calling thunk
+    (let ((result1 ;; compute promise's value without holding the state lock
            (let ()
              (declare (interrupts-enabled))
              (thunk))))
+      (macro-lock-promise-states!)
       (let ((state1 (##promise-state promise)))
         (cond ((and (macro-reentrant-semantics? state1)
                     (##not (##eq? state1 ;; is it determined now?
                                   (##vector-ref state1 0))))
-               (##vector-ref state1 0)) ;; ignore thunk's result
+               (macro-unlock-and-return (##vector-ref state1 0)))
               ((##not (##promise? result1))
                (##vector-set! state1 0 result1) ;; cache promise's value
                (if (macro-reentrant-semantics? state1)
                    (##vector-set! state1 1 #f))
-               result1)
+               (macro-unlock-and-return result1))
               (else
                ;; result1 is a promise, so we need to force it
                (let* ((state2 (##promise-state result1))
@@ -1890,12 +1917,13 @@ end-of-code
                         (##vector-set! state1 0 result2) ;; cache promise's value
                         (if (macro-reentrant-semantics? state1)
                             (##vector-set! state1 1 #f))
-                        result2)
+                        (macro-unlock-and-return result2))
                        (else
                         (let ((t (##vector-ref state2 1)))
                           (##promise-state-set! result1 state1) ;; link states
                           (cond ((macro-reentrant-semantics? state2)
                                  (##vector-set! state1 1 t)
+                                 (macro-unlock-promise-states!)
                                  (chase promise t))
                                 ((##not t)
                                  (nonreentrant-undetermined-case promise))
@@ -1903,19 +1931,23 @@ end-of-code
                                  ;; avoid space leak through thunk
                                  (if (macro-reentrant-semantics? state2)
                                      (##vector-set! state2 1 #f))
+                                 (macro-unlock-promise-states!)
                                  (chase promise t))))))))))))
 
+  (macro-lock-promise-states!)
   (let ((state (##promise-state promise)))
     (if (##not (##eq? state (##vector-ref state 0))) ;; is promise determined?
-        (##vector-ref state 0) ;; return cached value
+        (macro-unlock-and-return (##vector-ref state 0))
         (let ((thunk (##vector-ref state 1)))
           (cond ((macro-reentrant-semantics? state)
+                 (macro-unlock-promise-states!)
                  (chase promise thunk))
                 ((##not thunk)
                  (nonreentrant-undetermined-case promise))
                 (else
                  ;; avoid space leak through thunk
                  (##vector-set! state 1 #f)
+                 (macro-unlock-promise-states!)
                  (chase promise thunk)))))))
 
 ;;;----------------------------------------------------------------------------

--- a/tests/unit-tests/14-control/promise.scm
+++ b/tests/unit-tests/14-control/promise.scm
@@ -1,0 +1,81 @@
+(include "#.scm")
+
+(test-eqv 42 (force 42))
+(let ((p (delay (list 'value))))
+  (test-equal '(value) (force p))
+  (test-eq (force p) (force p)))
+
+;; Reentrant forcing must retain the value cached by the inner force.
+(letrec ((count 0)
+         (p (delay
+              (begin
+                (set! count (+ count 1))
+                (if (< count 6) (force p) count)))))
+  (test-eqv 6 (force p))
+  (test-eqv 6 (force p))
+  (test-eqv 6 count))
+
+;; An exception must not leave a promise-state lock held.
+(let* ((first? #t)
+       (p (delay
+            (if first?
+                (begin (set! first? #f) (raise 'retry))
+                'value))))
+  (test-eq 'retry (with-exception-catcher (lambda (e) e)
+                   (lambda () (force p))))
+  (test-eq 'value (force p)))
+
+(let loop ((n 10000) (p (delay 'value)))
+  (if (= n 0)
+      (test-eq 'value (force p))
+      (loop (- n 1) (delay-force p))))
+
+;; Each worker records its own results; only promises are shared.
+;; Check both completion and object identity, not just equal contents.
+(define (check-concurrent-force wrap)
+  (let* ((n 20000)
+         (promises (make-vector n))
+         (results (list (make-vector n) (make-vector n)))
+         (threads '()))
+    (let loop ((i 0))
+      (if (< i n)
+          (begin
+            (vector-set!
+             promises i
+             (wrap
+              (delay
+                (let spin ((j 30))
+                  (if (> j 0) (spin (- j 1)) (list i))))))
+            (loop (+ i 1)))))
+    (set! threads
+          (map (lambda (result)
+                 (make-thread
+                  (lambda ()
+                    (let loop ((i 0))
+                      (if (< i n)
+                          (begin
+                            (vector-set! result i
+                                         (force (vector-ref promises i)))
+                            (loop (+ i 1)))))
+                    'done)))
+               results))
+    (for-each thread-start! threads)
+    (let ((completed
+           (map (lambda (thread) (thread-join! thread 20 'timeout)) threads)))
+      (test-equal '(done done) completed)
+      (if (equal? completed '(done done))
+          (let loop ((i 0) (mismatches 0))
+            (if (= i n)
+                (test-eqv 0 mismatches)
+                (let ((a (vector-ref (car results) i))
+                      (b (vector-ref (cadr results) i))
+                      (cached (force (vector-ref promises i))))
+                  (loop (+ i 1)
+                        (+ mismatches
+                           (if (and (eq? a b) (eq? a cached)
+                                    (equal? a (list i)))
+                               0 1))))))
+          (for-each thread-terminate! threads)))))
+
+(check-concurrent-force (lambda (p) p))
+(check-concurrent-force (lambda (p) (delay-force p)))


### PR DESCRIPTION
Two threads forcing the same promise can receive distinct result objects in an SMP build. `##force-out-of-line` disables interrupts around its cache operations, but this does not serialize processors: both can observe an undetermined promise and publish their own result.

Protect the short promise-state reads, cache updates and `delay-force` state linking with a VM-local ticket lock. One lock covers transitions involving two states. Release it before calling any delayed expression or chasing another promise, preserving reentrant forcing, exception retry and tail forcing. The lock macros expand to no-ops in unicore builds.

Adds `14-control/promise.scm` covering cached identity, recursive forcing, retry after an exception, a 10,000-element `delay-force` chain, and two-thread identity checks for 20,000 plain and wrapped promises. Worker joins are bounded.

Validation on macOS arm64 at `dcd677cd3e40860bdd27dfbdbf5e3ce46ab03813`, SMP configured with `--enable-smp --enable-multiple-threaded-vms --enable-c-opt=-O1`:

- The original public-API probe returned zero identity mismatches on baseline unicore and SMP p1, and 56 on baseline SMP p2. The candidate returned zero at p1/p2/p4.
- Both SMP and unicore `make core` builds completed. The full new regression passes on preserved baseline unicore and rebuilt candidate unicore.
- All three `14-control` repository tests pass in both interpreted and compiled modes. Three additional direct runs of the new regression at `p2,m256M` all pass.
- Larger allocation-heavy runs at `p2,m64M` intermittently exit with signal 11 on both baseline and candidate. A corresponding two-thread control using ordinary procedures instead of promises also exits with signal 11 in all three runs on each runtime. That independent runtime failure remains unresolved; this change addresses inconsistent promise results. The optional module build also encountered compiler failures, so validation is limited to the core builds and selected tests above.

Run from `tests/`, replacing `-gsi` with `-gsc` for compiled mode:

```sh
GAMBOPT=p2,m256M ../gsi/gsi -:tl,~~bin=../bin,~~lib=../lib,~~include=../include -f ./run-unit-tests.scm -gsi unit-tests/14-control
```

Related to #760. This branch is based independently on master and contains only the runtime change and regression test.
